### PR TITLE
Fix: nettoie .env.example + .gitignore (marqueurs de merge + doublons)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,63 +1,11 @@
 # ============================================================
-#  .env.example — Agent IA de prospection B2B
+#  .env.example — Agent IA de prospection B2B (multi-secteurs)
 #  Copier en `.env` puis renseigner les vraies valeurs LOCALEMENT.
-#  `.env` est gitignoré : AUCUNE clé réelle ne doit être committée
-#  (repo public — voir issue #5 et CLAUDE.md).
+#  Chaque dev met ses propres clés. `.env` est gitignoré : AUCUNE
+#  clé réelle ne doit être committée (repo public — voir issue #5).
 #
-#  ⚠️ Mettre la valeur SEULE après le `=`, sans commentaire en fin
-#  de ligne (les commentaires en ligne polluent la valeur lue).
-# ============================================================
-
-# ---------- PostgreSQL ----------
-POSTGRES_DB=prospection_b2b
-POSTGRES_USER=scraper
-POSTGRES_PASSWORD=changeme_postgres
-# POSTGRES_HOST : 'localhost' en local, 'postgres' depuis un container Docker
-POSTGRES_HOST=localhost
-POSTGRES_PORT=5432
-
-# ---------- Qdrant ----------
-QDRANT_API_KEY=changeme_qdrant
-# QDRANT_HOST : 'localhost' en local, 'qdrant' depuis un container Docker
-QDRANT_HOST=localhost
-QDRANT_PORT=6333
-
-# ---------- LLM & Observabilité ----------
-ANTHROPIC_API_KEY=
-LANGCHAIN_API_KEY=
-LANGCHAIN_TRACING_V2=true
-LANGCHAIN_PROJECT=prospection-b2b
-
-# ---------- APIs collecte ----------
-# INSEE : portail-api.insee.fr → Application → Subscriptions → API Keys.
-# Auth = header 'X-INSEE-Api-Key-Integration', base https://api.insee.fr/api-sirene/3.11
-# Rate limit 30 req/min (accès open data).
-INSEE_API_KEY=
-# TAVILY : 1000 req/mois gratuit. Auth = header 'Authorization: Bearer <clé>'.
-TAVILY_API_KEY=
-# BLOCTEL : OBLIGATOIRE LÉGALEMENT — délai d'obtention 3-5 j ouvrés.
-BLOCTEL_API_KEY=
-# DROPCONTACT : 24€/mois.
-DROPCONTACT_API_KEY=
-
-# ---------- Paramètres campagne (valeurs d'EXEMPLE uniquement) ----------
-# En production ces critères viennent de la table criteres_ciblage du
-# client/de la campagne, jamais de variables d'environnement globales.
-# Ces defaults ne servent qu'aux runs --dry-run en local.
-TARGET_DEPTS=75,92,93,94
-TARGET_NAF=4520Z,4511Z,4531Z,4532Z
-MAX_PROSPECTS=500
-=======
-# =============================================================================
-# .env.example — Agent IA de Prospection B2B (multi-secteurs)
-# =============================================================================
-# Ce fichier liste TOUTES les variables d'environnement nécessaires au pipeline.
-# Il est versionné sans aucune valeur secrète. Chaque développeur copie ce
-# fichier en `.env` et renseigne ses propres clés.
-=======
-#
-#  ⚠️ Mettre la valeur SEULE après le `=`, sans commentaire en fin
-#  de ligne (les commentaires en ligne polluent la valeur lue).
+#  ⚠️ Valeur SEULE après le `=`, sans commentaire en fin de ligne
+#  (les commentaires en ligne polluent la valeur lue).
 # ============================================================
 
 # ---------- PostgreSQL ----------

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Contexte équipe privé — ne jamais committer (repo public)
 agents.md
 
@@ -7,7 +6,6 @@ agents.md
 .env
 .env.*
 !.env.example
-
 
 # Logs
 logs
@@ -18,34 +16,15 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
+# Node / frontend
 node_modules
 dist
 dist-ssr
 *.local
 
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-.idea
-.DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
-
-# Secrets — ne JAMAIS committer le .env réel (seul .env.example est versionné)
-.env
-.env.*
-
 # Python
 __pycache__/
 *.py[cod]
-
-.venv/
-venv/
-.pytest_cache/
-=======
 *.egg-info/
 .venv/
 venv/
@@ -58,10 +37,16 @@ backups/
 *.sql.gz
 
 # IDE / OS
-.vscode/
+.vscode/*
+!.vscode/extensions.json
 .idea/
 .DS_Store
 Thumbs.db
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
 
 # Claude / BMad (artefacts locaux)
 .claude/
@@ -70,5 +55,3 @@ _bmad-output/
 
 # Scripts locaux
 use-ollama.ps1
-
-


### PR DESCRIPTION
Le merge de #44 et #47/#48 (setup `.env` fait en parallèle) a laissé des
marqueurs `=======` et des doublons dans les deux fichiers.

**`.env.example`** : chaque var était définie 2× (INSEE_API_KEY, POSTGRES_DB…).
dotenv = last-wins → le doublon vide en fin de fichier écrase silencieusement
une clé qu'on vient de remplir. Réduit à un seul bloc (101 → 49 lignes).

**`.gitignore`** : marqueur `=======` + règles `.env` dupliquées (le 2e `.env.*`
ré-ignorait `.env.example` faute de `!`). Dédupliqué, `!.env.example` gardé.

Aucune valeur secrète touchée, toutes les règles d'ignore de chacun conservées.