### PR TITLE
docs: CLAUDE.md — section "état réel & pièges" (Sprint 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,34 @@ Agent IA générique qui scrape des entreprises (Sirene INSEE) selon le profil c
 
 **Le produit n'est spécifique à aucun secteur.** Chaque client configure son propre ICP (codes NAF, effectif, ancienneté, zone géographique, mots-clés positifs/négatifs) via `criteres_ciblage` en base — aucune valeur métier ne doit être codée en dur dans l'agent.
 
+## État réel du repo & pièges (MAJ 2026-08-02)
+
+Sprint 1 en cours. Sur `main` : docker-compose (#6), schéma SQL (#7), front
+React/Vite. Le back Python arrive (embeddings #8 + `utils/db.py` #9 en revue).
+L'arborescence Python complète (#11) et le pipeline (`main.py`) n'existent pas
+encore. Les « Commandes du quotidien » plus bas sont la **cible**, pas l'état actuel.
+
+**Monorepo** : le front (React/Vite/shadcn) ET le back Python vivent à la
+**racine** — `config/`, `utils/`, `docker/` cohabitent avec `src/`, `package.json`.
+
+Pièges connus (drift docs ↔ réalité — vérifier avant de coder) :
+- **Numérotation des issues** : `docs/ISSUES.md` numérote le Sprint 0 en `#S0-x` ;
+  sur GitHub ce sont les issues #1–5, donc **tout est décalé de +5**. Ex. : « #5
+  Pydantic » dans la doc = issue GitHub **#10**. Toujours mapper avant de citer.
+- **11 tables, pas 8** : le schéma ajoute `bloctel_verifications`,
+  `oppositions_rgpd`, `purge_rgpd_log` aux 8 documentées.
+- **INSEE** : nouveau portail `api-sirene/3.11` + header
+  `X-INSEE-Api-Key-Integration` (et non l'ancien `entreprises/sirene/V3.11` + OAuth2).
+- **Fins de ligne** : `.gitattributes` force LF sur `*.sh`. Ne pas réintroduire de
+  CRLF — ça casse les entrypoints Docker (crash en boucle du container Ollama).
+- **Qdrant** : `qdrant-client` doit suivre la version du serveur du docker
+  (~1.15.x). Créer les **index payload** à la création des collections, sinon le
+  filtrage (`departement`, `code_naf`) fait un scan séquentiel lent.
+
+**Lancer la stack en local** : `docker compose --profile dev up -d` (pas de `make`
+garanti sous Windows). Tests d'intégration marqués `@pytest.mark.integration`
+(tapent de vraies APIs) — exclus des runs par défaut.
+
 ## Repo & équipe
 
 ```
@@ -34,7 +62,7 @@ Durée   : 9 semaines MVP
 2. **Sources légales uniquement** : Sirene INSEE, Tavily, Pappers. Zéro scraping illégal.
 3. **Aucun ICP codé en dur** : codes NAF, tranche d'effectif, ancienneté, zone géographique, mots-clés positifs/négatifs viennent tous de `criteres_ciblage` / `icp_profiles` en base, jamais de constantes Python. Un client = un ICP = une configuration.
 4. **Exclusions configurables par client** (`criteres_ciblage.mots_cles_negatifs`) — jamais de liste de marques/groupes codée en dur. Un prospect qui matche une exclusion → score = 0 automatiquement.
-5. **Embeddings locaux sur CPU** : Ollama + `nomic-embed-text` (tag Ollama = v1.5, 137 MB, 768 dims). Pas d'API OpenAI pour ça. Modèle configurable via `OLLAMA_EMBED_MODEL`.
+5. **Embeddings locaux sur CPU** : Ollama + `nomic-embed-text` (tag Ollama = v1.5, ~274 MB au téléchargement / 137M paramètres, 768 dims). Pas d'API OpenAI pour ça. Modèle configurable via `OLLAMA_EMBED_MODEL`.
 6. **LLM scorer en cloud** : Claude API uniquement (CPU OVH trop lent pour inférence locale). Voir `docs/SCORING.md` pour le choix de modèle et le prompt caching.
 7. **Pydantic v2 partout** : tous les modèles de données passent par Pydantic avec validators.
 8. **Async partout** : asyncpg pour Postgres, AsyncQdrantClient pour Qdrant, httpx pour HTTP.


### PR DESCRIPTION
Ajoute dans `CLAUDE.md` une section qui capitalise les pièges rencontrés pendant le Sprint 1, pour que les prochaines sessions (Claude Code ou humain) ne les redécouvrent pas.

### Contenu
- **État réel** : monorepo front (React/Vite) + back Python à la racine ; ce qui existe vraiment sur `main` vs la cible.
- **Pièges docs ↔ réalité** :
  - numérotation issues décalée (`docs/ISSUES.md` #S0-x = GitHub +5)
  - 11 tables, pas 8
  - INSEE : portail `api-sirene/3.11` + header `X-INSEE-Api-Key-Integration`
  - `.gitattributes` LF sur `*.sh` (sinon crash Ollama sous Windows)
  - `qdrant-client` aligné sur le serveur + index payload obligatoires pour le filtrage
- **Lancer en local** sans `make` (Windows).

### + fix règle #5
`nomic-embed-text` = **~274 MB** au téléchargement (137M *paramètres*), la doc disait "137 MB" (confusion taille/params). Sources : [Ollama](https://ollama.com/library/nomic-embed-text), [Qdrant filtering](https://qdrant.tech/articles/vector-search-filtering/).

Docs uniquement, aucun code touché.