### PR TITLE
feat(#10): modèles Pydantic v2 — Prospect, Score, CriteresCiblage, EtatAgent

### DIFF
--- a/graph/state.py
+++ b/graph/state.py
@@ -1,0 +1,30 @@
+"""État partagé du graphe LangChain (règles #7/#8, issue #10).
+
+`EtatAgent` est le TypedDict passé entre les 6 nodes du pipeline (#28) :
+init_campagne -> fetch_sirene -> enrichir -> nettoyer -> scorer -> sauvegarder.
+
+`total=False` : les champs se remplissent progressivement au fil du pipeline
+(un node lit ce qui existe déjà et ajoute sa contribution). La forme définitive
+sera confirmée à l'assemblage du graphe (#28).
+"""
+from typing import TypedDict
+
+from models.criteres import CriteresCiblage
+from models.prospect import Prospect
+
+
+class EtatAgent(TypedDict, total=False):
+    # Contexte de campagne (posé par init_campagne, #16)
+    campagne_id: str
+    client_id: str
+    criteres: CriteresCiblage
+    icp_embedding: list[float] | None
+
+    # Données en cours de traitement
+    prospects: list[Prospect]
+    config_scoring: dict  # poids des 3 couches (depuis campagnes.config_scoring)
+
+    # Suivi d'exécution
+    erreurs: list[str]
+    collectes: int
+    qualifies: int

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,5 @@
+from models.criteres import CriteresCiblage
+from models.prospect import Prospect
+from models.score import ScoreResult
+
+__all__ = ["CriteresCiblage", "Prospect", "ScoreResult"]

--- a/models/criteres.py
+++ b/models/criteres.py
@@ -1,0 +1,32 @@
+"""Modèle Pydantic v2 de l'ICP configurable par client (règle #3, issue #10).
+
+Miroir de la table `criteres_ciblage`. Chargé depuis la BDD par `init_campagne`
+(#16), injecté dans `EtatAgent`, puis consommé par le scoring règles (#24).
+**Toute** valeur métier (NAF, effectif, mots-clés) vient d'ici — jamais du code.
+"""
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class CriteresCiblage(BaseModel):
+    id: UUID | None = None
+    client_id: UUID | None = None
+    nom: str
+    description_icp: str | None = None
+    codes_naf: list[str] = Field(default_factory=list)
+    departements: list[str] = Field(default_factory=list)
+    effectif_min: int = Field(default=1, ge=0)
+    effectif_max: int = Field(default=500)
+    anciennete_min_ans: int = Field(default=0, ge=0)
+    exiger_site_web: bool = False
+    exiger_email: bool = False
+    mots_cles_positifs: list[str] = Field(default_factory=list)
+    mots_cles_negatifs: list[str] = Field(default_factory=list)
+    actif: bool = True
+
+    @model_validator(mode="after")
+    def _check_effectifs(self) -> "CriteresCiblage":
+        if self.effectif_max < self.effectif_min:
+            raise ValueError("effectif_max doit être >= effectif_min.")
+        return self

--- a/models/prospect.py
+++ b/models/prospect.py
@@ -1,0 +1,171 @@
+"""Modèle Pydantic v2 du prospect (règle #7, issue #10).
+
+Miroir des colonnes de la table `prospects` (`docker/postgres/init/01_schema.sql`),
+avec les validators de nettoyage des données scrapées :
+
+- `telephone` / `telephone_2` -> E.164 via `phonenumbers` (None si invalide) ;
+- `email` -> validé (lib `email-validator`) puis None si syntaxe KO OU domaine
+  blacklisté (cf. `docs/SCORING.md`) — jamais bloquant ;
+- `siret` / `siren` -> checksum Luhn via `python-stdnum` (+ exception La Poste) ;
+- `to_db_dict()` -> dict natif compatible asyncpg, clés ⊆ whitelist de
+  `utils/db.py::_PROSPECT_COLUMNS`.
+"""
+import re
+from datetime import date, datetime
+from uuid import UUID
+
+import phonenumbers
+from email_validator import EmailNotValidError, validate_email
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from stdnum.fr import siren as _stdnum_siren
+from stdnum.fr import siret as _stdnum_siret
+
+# Emails à écarter (score email = 0) — cf. docs/SCORING.md. Mélange de domaines
+# et de préfixes de partie locale : matching par sous-chaîne, insensible casse.
+EMAIL_BLACKLIST_DOMAINS = (
+    "pagesjaunes.fr", "laposte.net", "noreply.", "contact@", "info@", "mairie.",
+)
+
+# Statuts autorisés (CHECK de la table prospects).
+STATUTS_PROSPECT = (
+    "nouveau", "qualifie", "en_attente_appel", "appele", "rdv", "refus",
+    "absent", "invalide",
+)
+
+# Colonnes émises par to_db_dict — sous-ensemble strict de la whitelist de
+# utils/db.py. Exclut les score_* (posés par save_score) et les colonnes
+# auto-générées (id, created_at, updated_at).
+_DB_FIELDS = {
+    "campagne_id", "source_id", "siret", "siren", "nom_entreprise",
+    "nom_dirigeant", "code_naf", "libelle_naf", "telephone", "telephone_2",
+    "email", "site_web", "adresse", "code_postal", "ville", "departement",
+    "latitude", "longitude", "effectif", "effectif_code", "effectif_estime",
+    "date_creation", "chiffre_affaire", "statut", "bloctel_ok",
+    "bloctel_verifie_le", "doublon", "qdrant_point_id", "notes", "raw_data",
+}
+
+
+def _normalize_phone(raw: str) -> str | None:
+    """Numéro FR -> E.164 (`+33…`). None si non parsable ou invalide."""
+    try:
+        num = phonenumbers.parse(raw, "FR")
+    except phonenumbers.NumberParseException:
+        return None
+    if phonenumbers.is_valid_number(num):
+        return phonenumbers.format_number(num, phonenumbers.PhoneNumberFormat.E164)
+    return None
+
+
+def _clean_email(raw: str) -> str | None:
+    """Email normalisé, ou None si syntaxe invalide ou domaine blacklisté."""
+    try:
+        normalized = validate_email(raw, check_deliverability=False).normalized
+    except EmailNotValidError:
+        return None
+    if any(token in normalized.lower() for token in EMAIL_BLACKLIST_DOMAINS):
+        return None
+    return normalized
+
+
+def _valid_siret(s: str) -> bool:
+    """14 chiffres + Luhn, avec l'exception La Poste (SIREN 356000000 :
+    somme des 14 chiffres multiple de 5, cf. INSEE)."""
+    if not (len(s) == 14 and s.isdigit()):
+        return False
+    if _stdnum_siret.is_valid(s):
+        return True
+    return s.startswith("356000000") and sum(int(d) for d in s) % 5 == 0
+
+
+class Prospect(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    # Rattachement
+    campagne_id: UUID
+    source_id: UUID | None = None
+
+    # Identité entreprise
+    siret: str | None = None
+    siren: str | None = None
+    nom_entreprise: str
+    nom_dirigeant: str | None = None
+    code_naf: str | None = None
+    libelle_naf: str | None = None
+
+    # Contact
+    telephone: str | None = None
+    telephone_2: str | None = None
+    email: str | None = None
+    site_web: str | None = None
+
+    # Adresse
+    adresse: str | None = None
+    code_postal: str | None = None
+    ville: str | None = None
+    departement: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+
+    # Business
+    effectif: str | None = None
+    effectif_code: str | None = None
+    effectif_estime: int | None = None
+    date_creation: date | None = None
+    chiffre_affaire: str | None = None
+
+    # Pipeline
+    statut: str = "nouveau"
+    bloctel_ok: bool | None = None
+    bloctel_verifie_le: datetime | None = None
+    doublon: bool = False
+    qdrant_point_id: UUID | None = None
+
+    # Debug / traçabilité
+    notes: str | None = None
+    raw_data: dict = Field(default_factory=dict)
+
+    @field_validator("telephone", "telephone_2", mode="before")
+    @classmethod
+    def _v_phone(cls, v: object) -> str | None:
+        if v is None or v == "":
+            return None
+        return _normalize_phone(str(v))
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def _v_email(cls, v: object) -> str | None:
+        if v is None or v == "":
+            return None
+        return _clean_email(str(v))
+
+    @field_validator("siret", mode="before")
+    @classmethod
+    def _v_siret(cls, v: object) -> str | None:
+        if v is None or v == "":
+            return None
+        s = re.sub(r"\s", "", str(v))
+        if not _valid_siret(s):
+            raise ValueError("SIRET invalide (14 chiffres + checksum Luhn requis).")
+        return s
+
+    @field_validator("siren", mode="before")
+    @classmethod
+    def _v_siren(cls, v: object) -> str | None:
+        if v is None or v == "":
+            return None
+        s = re.sub(r"\s", "", str(v))
+        if not (len(s) == 9 and s.isdigit() and _stdnum_siren.is_valid(s)):
+            raise ValueError("SIREN invalide (9 chiffres + checksum Luhn requis).")
+        return s
+
+    @field_validator("statut")
+    @classmethod
+    def _v_statut(cls, v: str) -> str:
+        if v not in STATUTS_PROSPECT:
+            raise ValueError(f"statut invalide : {v!r} (attendu l'un de {STATUTS_PROSPECT}).")
+        return v
+
+    def to_db_dict(self) -> dict:
+        """dict natif (types Python : UUID, date, dict…) prêt pour asyncpg.
+        Clés = sous-ensemble de utils/db.py::_PROSPECT_COLUMNS."""
+        return self.model_dump(mode="python", include=_DB_FIELDS)

--- a/models/score.py
+++ b/models/score.py
@@ -1,0 +1,22 @@
+"""Modèle Pydantic v2 du résultat de scoring (règle #7, issue #10).
+
+Agrège les 3 couches du scoring hybride (règles / LLM / embedding) et la sortie
+structurée du LLM (justification, signaux, priorité). Voir `docs/SCORING.md`.
+"""
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ScoreResult(BaseModel):
+    # Sous-scores des 3 couches
+    score_regles: int = Field(ge=0, le=100)
+    score_llm: int = Field(ge=0, le=100)
+    score_embedding: float = Field(ge=0.0, le=1.0)  # similarité cosinus
+    score_final: int = Field(ge=0, le=100)
+
+    # Sortie structurée du LLM (cf. docs/SCORING.md)
+    justification_llm: str = ""
+    signaux_positifs: list[str] = Field(default_factory=list)
+    signaux_negatifs: list[str] = Field(default_factory=list)
+    priorite: Literal["haute", "moyenne", "basse"] = "moyenne"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,8 @@ qdrant-client>=1.15,<1.16
 httpx>=0.27,<0.29
 pydantic>=2.7,<3.0
 pydantic-settings>=2.3,<3.0
+
+# Validation des modèles (issue #10)
+phonenumbers>=8.13            # normalisation téléphone -> E.164
+email-validator>=2.1          # validation email RFC (utilisé par le validator, pas EmailStr)
+python-stdnum>=1.19           # SIRET/SIREN : checksum Luhn + exception La Poste


### PR DESCRIPTION
## Contexte
Modélise en Pydantic v2 (règle #7) les structures centrales du pipeline. Base pour la collecte (#15), le scoring (#24-26) et l'assemblage du graphe (#28). Rebasé sur main après le merge de #53 → diff propre (7 fichiers, uniquement #10).

## Modèles
- **Prospect** — miroir de la table `prospects` + validators de nettoyage.
- **ScoreResult** — 3 sous-scores + sortie LLM (justification, signaux, priorité).
- **CriteresCiblage** — l'ICP (miroir `criteres_ciblage`). Ajouté car requis par EtatAgent + le scoring (#24), bien que hors de la liste initiale de l'issue.
- **EtatAgent** (`graph/state.py`) — TypedDict partagé entre les 6 nodes (#28).

## Validators (choix)
- **telephone → E.164** (`phonenumbers`) ; invalide → None (lenient).
- **email** via `email-validator` (pas de regex maison) + blacklist domaines (SCORING.md) ; KO/blacklist → None, jamais bloquant.
- **siret/siren → checksum Luhn** (`python-stdnum`), **avec exception La Poste** (SIREN 356000000 : somme des chiffres multiple de 5). Invalide → ValidationError.
- **to_db_dict()** → dict natif asyncpg, clés **⊆ `utils/db.py::_PROSPECT_COLUMNS`** (contrat avec #9), exclut les `score_*` (gérés par `save_score`).

Deps : `phonenumbers`, `email-validator`, `python-stdnum`.

## Tests
Acceptance vérifiée en local — **19/19** (E.164, SIRET Luhn + La Poste, blacklist emails, statut, `to_db_dict` contrat + types, bornes scores/critères). Les tests unitaires **formels** sont l'issue séparée **#13**.

## Note légale
Le validator téléphone normalise seulement ; la callabilité d'un numéro (dont le cas auto-entrepreneurs/particuliers, loi 2025-594) est gérée en aval (Bloctel #20, phase vocale). Pas de flag personne physique/morale ici.