### PR TITLE
feat(#4): saisie configuration ICP par client (script + seed pilote +…

### DIFF
--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -13,3 +13,16 @@
 - Stack dev binds 0.0.0.0 avec creds `changeme` — acceptable en local ; l'exposition prod est gérée par l'override 127.0.0.1.
 - Port gRPC Qdrant 6334 exposé — utilisé par `AsyncQdrantClient` (CLAUDE.md) ; prod le lie à 127.0.0.1.
 - docker-compose v1 (binaire hyphen) non supporté — l'env cible a compose v2 ; documenter.
+## Deferred from: code review of spec-gh-4-modele-icp (2026-08-04)
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-gh-4-modele-icp.md`
+  summary: Race condition TOCTOU sur l'upsert applicatif (`_upsert_criteres`/`_upsert_icp_profile` : SELECT-then-INSERT non atomique → doublon si exécutions parallèles).
+  evidence: Le schéma `criteres_ciblage`/`icp_profiles` n'a pas de contrainte UNIQUE sur `(client_id, nom)` (spéc #4 interdit de modifier le schéma #7). Sans `ON CONFLICT` possible, deux seeds parallèles sur le même client+nom créent deux lignes. Fix propre = migration ajoutant `UNIQUE (client_id, nom)` (story séparée, hors scope #4).
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-gh-4-modele-icp.md`
+  summary: `clients.contact_email` UNIQUE — collision non catchée (`asyncpg.UniqueViolationError`) si deux clients seedés avec le même email non-null.
+  evidence: `icp_payload.py` n'a pas de validator `EmailStr` et `seed_icp.py` ne catche pas `UniqueViolationError`. Faible car `contact_email` est Optional et souvent None (NULLs distincts en PG). À gérer quand le front saisira de vrais contacts.
+
+- source_spec: `_bmad-output/implementation-artifacts/spec-gh-4-modele-icp.md`
+  summary: Garde-fou anti-hardcodage ne détecte pas les hardcodages dynamiques (concaténation `"4520"+"Z"`, f-string, variable externe, `list("4520Z")`).
+  evidence: Limitation structurelle d'un scan AST statique sur les `ast.Constant`. C'est un garde-fou d'alerte, pas une preuve formelle. Documenté dans la docstring du test. Amélioration possible = analyse de dataflow, hors scope MVP.

--- a/config/icp_seed_example.py
+++ b/config/icp_seed_example.py
@@ -1,0 +1,50 @@
+"""ICP pilote — DONNÉE DE TEST, pas valeur par défaut du produit (issue #4).
+
+Ce fichier est l'unique emplacement légitime contenant des valeurs métier ICP
+concrètes (codes NAF, mots-clés sectoriels). Le garde-fou
+`tests/test_no_hardcoded_icp.py` l'exclut explicitement de son scan.
+
+Il illustre comment amorcer un nouveau client : un vrai client saisira son
+propre ICP via `scripts/seed_icp.py --from-file <son-icp.json>`. Le seed
+« garages » ci-dessous n'est jamais chargé en production comme défaut —
+c'est un exemple pour bootstrap et les tests d'intégration.
+
+L'embedding Qdrant de cet ICP n'est PAS généré ici (c'est l'issue #12).
+On ne remplit que `clients` + `criteres_ciblage` + `icp_profiles`.
+"""
+from __future__ import annotations
+
+# ICP pilote : garages indépendants (issue #4, livrable #3).
+# L'objectif de prospection ciblé : garages auto/moto indépendants, petite
+# structure, installés depuis au moins 3 ans (stabilité financière).
+ICP_SEEDS: dict[str, dict] = {
+    "garages": {
+        # --- clients ---
+        "nom_entreprise": "Client Pilote — Garages",
+        "secteur": "Garages automobiles indépendants",
+        "produit_vendu": "Logiciel SaaS de gestion d'atelier",
+        "zone_intervention": "France métropolitaine",
+        "contact_nom": None,
+        "contact_email": None,
+        "contact_telephone": None,
+        # --- criteres_ciblage ---
+        "nom": "Garages indépendants — cible pilote",
+        "description_icp": (
+            "Garages automobiles et motos indépendants, structure artisanale "
+            "de 2 à 15 salariés, en activité depuis au moins 3 ans. Ciblent "
+            "les réparateurs multi-marques plutôt que les concessions."
+        ),
+        # Codes NAF : réparation auto (4520Z), vente auto (4511Z),
+        # réparation moto (4540Z — non inclus, hors cible), entretien/carrosserie
+        # (4531Z), installation équipements auto (4532Z).
+        "codes_naf": ["4520Z", "4511Z", "4531Z", "4532Z"],
+        "departements": [],  # pas de restriction géo dans l'exemple pilote
+        "effectif_min": 2,
+        "effectif_max": 15,
+        "anciennete_min_ans": 3,
+        "exiger_site_web": False,
+        "exiger_email": True,
+        "mots_cles_positifs": ["réparation", "multi-marques", "atelier"],
+        "mots_cles_negatifs": ["concession", "groupe", "centrale"],
+    },
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ qdrant-client>=1.15,<1.16
 httpx>=0.27,<0.29
 pydantic>=2.7,<3.0
 pydantic-settings>=2.3,<3.0
+
+# --- Dev (tests) ---
+pytest>=8.0,<9.0
+pytest-asyncio>=0.23,<0.25

--- a/scripts/seed_icp.py
+++ b/scripts/seed_icp.py
@@ -1,0 +1,268 @@
+"""Script de saisie d'une configuration ICP par client (issue #4).
+
+Insère (ou met à jour) un client + ses `criteres_ciblage` + un `icp_profiles`
+en base PostgreSQL, en réutilisant `utils/db.py` (pool asyncpg). Aucune
+valeur métier n'est codée en dur ici : tout vient d'un fichier fourni par
+l'appelant ou du seed exemplaire `config/icp_seed_example.py` (donnée de
+test, pas défaut prod).
+
+L'idempotence est gérée applicativement (le schéma actuel n'a pas de
+contrainte UNIQUE sur `(client_id, nom)`) : on SELECT puis UPDATE ou INSERT.
+
+Usage :
+    # Dry-run (aucune écriture, valide juste le payload)
+    python scripts/seed_icp.py --from-example garages --dry-run
+
+    # Nouveau client depuis le seed garages
+    python scripts/seed_icp.py --from-example garages
+
+    # Nouveau client depuis un fichier JSON personnalisé
+    python scripts/seed_icp.py --from-file mon-icp.json
+
+    # Mise à jour d'un client existant
+    python scripts/seed_icp.py --from-file mon-icp-v2.json --client-id <uuid>
+
+Ne génère PAS l'embedding Qdrant (c'est l'issue #12).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+# Permet `python scripts/seed_icp.py` depuis la racine du repo sans install.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from config.icp_seed_example import ICP_SEEDS  # noqa: E402
+from utils.icp_payload import IcpPayload, normalize  # noqa: E402
+
+
+def _load_payload(args: argparse.Namespace) -> dict[str, Any]:
+    """Construit le dict brut du payload depuis `--from-example` ou `--from-file`."""
+    if args.from_example:
+        if args.from_example not in ICP_SEEDS:
+            available = ", ".join(sorted(ICP_SEEDS))
+            raise SystemExit(
+                f"Seed exemple inconnu : '{args.from_example}'. "
+                f"Disponibles : {available}"
+            )
+        return dict(ICP_SEEDS[args.from_example])
+
+    if args.from_file:
+        path = Path(args.from_file)
+        if not path.exists():
+            raise SystemExit(f"Fichier introuvable : {path}")
+        if path.is_dir():
+            raise SystemExit(f"Le chemin est un répertoire, pas un fichier : {path}")
+        try:
+            with path.open(encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"JSON invalide dans {path} : {exc}") from exc
+        except UnicodeDecodeError as exc:
+            raise SystemExit(
+                f"Encodage non-UTF8 dans {path} : convertis le fichier en UTF-8. "
+                f"({exc})"
+            ) from exc
+
+    raise SystemExit(
+        "Il faut fournir --from-example <nom> ou --from-file <path.json>."
+    )
+
+
+async def _upsert_client(conn, p: IcpPayload, client_id: uuid.UUID | None) -> uuid.UUID:
+    """Insère un nouveau client ou renvoie l'UUID existant (pas de doublon).
+
+    Si `client_id` est fourni et existe, on ne touche pas à la fiche client
+    (la mise à jour porte sur les critères, pas sur l'identité du client).
+    """
+    if client_id is not None:
+        exists = await conn.fetchval(
+            "SELECT 1 FROM clients WHERE id = $1", client_id
+        )
+        if not exists:
+            # Ask First (spec) : FK violée — on HALT avant d'insérer.
+            raise SystemExit(
+                f"client-id {client_id} introuvable en base. Création d'un "
+                f"nouveau client refusée sans confirmation (Ask First). "
+                f"Re-exécutez sans --client-id pour créer un nouveau client."
+            )
+        return client_id
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO clients (nom_entreprise, secteur, produit_vendu,
+            zone_intervention, contact_nom, contact_email, contact_telephone)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING id;
+        """,
+        p.nom_entreprise, p.secteur, p.produit_vendu, p.zone_intervention,
+        p.contact_nom, p.contact_email, p.contact_telephone,
+    )
+    return row["id"]
+
+
+async def _upsert_criteres(conn, client_id: uuid.UUID, p: IcpPayload) -> uuid.UUID:
+    """Upsert applicatif sur `criteres_ciblage` (client_id, nom)."""
+    existing = await conn.fetchval(
+        "SELECT id FROM criteres_ciblage WHERE client_id = $1 AND nom = $2",
+        client_id, p.nom,
+    )
+    fields = p.to_criteres_row()
+    if existing is not None:
+        await conn.execute(
+            """
+            UPDATE criteres_ciblage SET
+                description_icp = $2, codes_naf = $3, departements = $4,
+                effectif_min = $5, effectif_max = $6, anciennete_min_ans = $7,
+                exiger_site_web = $8, exiger_email = $9,
+                mots_cles_positifs = $10, mots_cles_negatifs = $11,
+                updated_at = NOW()
+            WHERE id = $1;
+            """,
+            existing, fields["description_icp"], fields["codes_naf"],
+            fields["departements"], fields["effectif_min"], fields["effectif_max"],
+            fields["anciennete_min_ans"], fields["exiger_site_web"],
+            fields["exiger_email"], fields["mots_cles_positifs"],
+            fields["mots_cles_negatifs"],
+        )
+        return existing
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO criteres_ciblage (client_id, nom, description_icp,
+            codes_naf, departements, effectif_min, effectif_max,
+            anciennete_min_ans, exiger_site_web, exiger_email,
+            mots_cles_positifs, mots_cles_negatifs)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        RETURNING id;
+        """,
+        client_id, fields["nom"], fields["description_icp"],
+        fields["codes_naf"], fields["departements"], fields["effectif_min"],
+        fields["effectif_max"], fields["anciennete_min_ans"],
+        fields["exiger_site_web"], fields["exiger_email"],
+        fields["mots_cles_positifs"], fields["mots_cles_negatifs"],
+    )
+    return row["id"]
+
+
+async def _upsert_icp_profile(
+    conn, client_id: uuid.UUID, critere_id: uuid.UUID, p: IcpPayload
+) -> uuid.UUID:
+    """Upsert applicatif sur `icp_profiles` (client_id, nom).
+
+    `description` reprend `description_icp` du critère : c'est le texte qui
+    sera embarqué plus tard par #12. `qdrant_point_id` reste NULL (embedding
+    non généré ici).
+    """
+    description = p.description_icp or p.nom
+    existing = await conn.fetchval(
+        "SELECT id FROM icp_profiles WHERE client_id = $1 AND nom = $2",
+        client_id, p.nom,
+    )
+    if existing is not None:
+        await conn.execute(
+            """
+            UPDATE icp_profiles SET critere_id = $2, description = $3,
+                -- La description ICP a changé → l'embedding Qdrant (généré par
+                -- #12) est devenu stale. On reset le point_id pour forcer une
+                -- re-génération lors du prochain init_icp.py.
+                qdrant_point_id = NULL, embedding_version = NULL,
+                updated_at = NOW()
+            WHERE id = $1;
+            """,
+            existing, critere_id, description,
+        )
+        return existing
+
+    row = await conn.fetchrow(
+        """
+        INSERT INTO icp_profiles (client_id, critere_id, nom, description)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id;
+        """,
+        client_id, critere_id, p.nom, description,
+    )
+    return row["id"]
+
+
+async def _run(args: argparse.Namespace) -> int:
+    raw = _load_payload(args)
+    try:
+        payload = normalize(raw)
+    except Exception as exc:  # pydantic.ValidationError + SystemExit remontés
+        if isinstance(exc, SystemExit):
+            raise
+        print(f"❌ Payload invalide : {exc}", file=sys.stderr)
+        return 2
+
+    if args.client_id:
+        try:
+            client_id = uuid.UUID(args.client_id)
+        except ValueError as exc:  # UUID mal formé
+            raise SystemExit(
+                f"--client-id invalide : '{args.client_id}' n'est pas un UUID "
+                f"valide (ex. 550e8400-e29b-41d4-a716-446655440000)."
+            ) from exc
+    else:
+        client_id = None
+
+    if args.dry_run:
+        print("[dry-run] Payload validé ✓")
+        print(json.dumps(
+            {"client": payload.to_client_row(),
+             "criteres": payload.to_criteres_row(),
+             "icp_description": payload.description_icp or payload.nom,
+             "client_id": str(client_id) if client_id else "<nouveau>"},
+            indent=2, ensure_ascii=False,
+        ))
+        print("[dry-run] Aucune écriture en base.")
+        return 0
+
+    from utils import db  # import différé : le dry-run n'a pas besoin de DB
+    try:
+        pool = await db.get_pg_pool()  # créé sur la loop courante
+        async with pool.acquire() as conn, conn.transaction():
+            cid = await _upsert_client(conn, payload, client_id)
+            crit_id = await _upsert_criteres(conn, cid, payload)
+            icp_id = await _upsert_icp_profile(conn, cid, crit_id, payload)
+            print(f"✓ client_id      : {cid}")
+            print(f"✓ critere_id     : {crit_id}")
+            print(f"✓ icp_profile_id : {icp_id}")
+    finally:
+        # Ferme le pool sur la MÊME loop que sa création (un second
+        # asyncio.run() laisserait les connexions orphelines).
+        await db.close()
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Saisie d'une configuration ICP par client (issue #4)."
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--from-example", metavar="NOM",
+                     help="Seed exemplaire (donnée de test), ex. 'garages'.")
+    src.add_argument("--from-file", metavar="PATH",
+                     help="Fichier JSON contenant le payload ICP.")
+    parser.add_argument("--client-id", metavar="UUID", default=None,
+                        help="UUID d'un client existant à mettre à jour.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Valide et affiche le payload sans écrire en base.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    # Un seul asyncio.run : le pool asyncpg y est créé ET fermé sur la même
+    # loop (un second asyncio.run laisserait les connexions liées à une loop
+    # fermée → RuntimeError "Event loop is closed").
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_icp_payload.py
+++ b/tests/test_icp_payload.py
@@ -1,0 +1,181 @@
+"""Tests unitaires de `utils/icp_payload.py` (validation Pydantic, sans DB).
+
+Couvre la I/O Matrix du spec : happy path + effectif inversé + aucun
+ciblage + NAF mal formé. Aucune dépendance Postgres/Qdrant nécessaire.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from utils.icp_payload import IcpPayload, normalize
+
+
+def _base() -> dict:
+    """Payload minimal valide — chaque test le dérive."""
+    return {
+        "nom_entreprise": "Cie", "secteur": "s", "produit_vendu": "p",
+        "zone_intervention": "z", "nom": "Cible test",
+        "codes_naf": ["4520Z"], "departements": ["75"],
+        "effectif_min": 2, "effectif_max": 15, "anciennete_min_ans": 3,
+    }
+
+
+# --- Happy path --------------------------------------------------------------
+
+def test_normalize_happy_path():
+    p = normalize(_base())
+    assert isinstance(p, IcpPayload)
+    assert p.codes_naf == ("4520Z",)
+    assert p.effectif_min == 2 and p.effectif_max == 15
+
+
+def test_string_list_coercion():
+    """Une chaîne CSV est acceptée et normalisée (ergonomie CLI/fichier)."""
+    raw = _base()
+    raw["codes_naf"] = "4520Z, 4511Z ,4531Z"
+    raw["departements"] = "75,92"
+    p = normalize(raw)
+    assert p.codes_naf == ("4520Z", "4511Z", "4531Z")
+    assert p.departements == ("75", "92")
+
+
+def test_to_criteres_row_returns_lists():
+    p = normalize(_base())
+    row = p.to_criteres_row()
+    assert row["codes_naf"] == ["4520Z"]
+    assert row["effectif_max"] == 15
+    assert isinstance(row["codes_naf"], list)
+
+
+# --- Error cases (I/O Matrix) ------------------------------------------------
+
+def test_effectif_inversed_rejected():
+    raw = _base()
+    raw["effectif_min"], raw["effectif_max"] = 20, 10
+    with pytest.raises(ValidationError) as exc_info:
+        normalize(raw)
+    assert "effectif_max" in str(exc_info.value)
+
+
+def test_no_ciblage_rejected():
+    """codes_naf ET departements vides → refus (aucun ciblage Sirene possible)."""
+    raw = _base()
+    raw["codes_naf"] = []
+    raw["departements"] = []
+    with pytest.raises(ValidationError) as exc_info:
+        normalize(raw)
+    assert "codes_naf ou departements" in str(exc_info.value)
+
+
+def test_only_departements_is_valid():
+    """Un ICP avec départements mais sans NAF est légitime (ciblage géo pur)."""
+    raw = _base()
+    raw["codes_naf"] = []
+    raw["departements"] = ["75", "92"]
+    p = normalize(raw)
+    assert p.codes_naf == () and p.departements == ("75", "92")
+
+
+def test_bad_naf_format_rejected():
+    raw = _base()
+    raw["codes_naf"] = ["4520"]  # manque la lettre
+    with pytest.raises(ValidationError) as exc_info:
+        normalize(raw)
+    assert "4520" in str(exc_info.value)
+
+
+def test_bad_departement_rejected():
+    raw = _base()
+    raw["departements"] = ["7A5"]  # lettre au milieu
+    with pytest.raises(ValidationError) as exc_info:
+        normalize(raw)
+    assert "7A5" in str(exc_info.value)
+
+
+def test_extra_field_forbidden():
+    """`extra='forbid'` : un champ inconnu est rejeté (anti-injection)."""
+    raw = _base()
+    raw["champ_malveillant"] = "x"
+    with pytest.raises(ValidationError):
+        normalize(raw)
+
+
+# --- P3 : effectif négatif rejeté par Pydantic (aligné sur CHECK SQL) -------
+
+def test_effectif_min_negative_rejected():
+    raw = _base()
+    raw["effectif_min"] = -5
+    with pytest.raises(ValidationError) as exc_info:
+        normalize(raw)
+    assert "effectif_min" in str(exc_info.value)
+
+
+def test_effectif_max_negative_rejected():
+    raw = _base()
+    raw["effectif_max"] = -1
+    with pytest.raises(ValidationError) as exc_info:
+        normalize(raw)
+    assert "effectif_max" in str(exc_info.value)
+
+
+# --- P4 : NAF minuscules normalisés en majuscules ---------------------------
+
+def test_naf_lowercase_normalized():
+    raw = _base()
+    raw["codes_naf"] = ["4520z"]
+    p = normalize(raw)
+    assert p.codes_naf == ("4520Z",)
+
+
+# --- P5 : doublons dédupliqués ----------------------------------------------
+
+def test_duplicates_dedup():
+    raw = _base()
+    raw["codes_naf"] = ["4520Z", "4520Z", "4511Z"]
+    p = normalize(raw)
+    assert p.codes_naf == ("4520Z", "4511Z")
+
+
+# --- P6 : Corse (2A/2B) acceptée --------------------------------------------
+
+def test_corse_departements_accepted():
+    raw = _base()
+    raw["departements"] = ["2A", "2B"]
+    p = normalize(raw)
+    assert p.departements == ("2A", "2B")
+
+
+def test_invalid_corse_variant_rejected():
+    """2C n'est pas un département réel → rejeté."""
+    raw = _base()
+    raw["departements"] = ["2C"]
+    with pytest.raises(ValidationError) as exc_info:
+        normalize(raw)
+    assert "2C" in str(exc_info.value)
+
+
+# --- P7 : chaînes required vides rejetées (min_length=1) --------------------
+
+def test_empty_nom_rejected():
+    raw = _base()
+    raw["nom"] = ""
+    with pytest.raises(ValidationError):
+        normalize(raw)
+
+
+def test_empty_nom_entreprise_rejected():
+    raw = _base()
+    raw["nom_entreprise"] = "   "  # strip puis min_length=1
+    with pytest.raises(ValidationError):
+        normalize(raw)
+
+
+# --- P8 : cohérence CSV vs liste sur entrées vides --------------------------
+
+def test_list_with_empty_entries_filtered():
+    """Une liste JSON avec entrées vides est filtrée (cohérent avec CSV)."""
+    raw = _base()
+    raw["departements"] = ["75", "", "92"]
+    p = normalize(raw)
+    assert p.departements == ("75", "92")

--- a/tests/test_no_hardcoded_icp.py
+++ b/tests/test_no_hardcoded_icp.py
@@ -1,0 +1,110 @@
+"""Garde-fou anti-hardcodage ICP (issue #4, livrable #2 — règle #3 CLAUDE.md).
+
+Détecte les valeurs métier ICP codées en dur dans le code Python de
+production : codes NAF ou mots-clés sectoriels placés comme **littéraux
+string** dans le code (éléments de liste, valeurs de retour, valeurs de
+dict). Échoue s'il en trouve en dehors de la whitelist.
+
+Approche AST (et non regex brute) pour éviter les faux positifs :
+- un code NAF dans un message d'erreur (`"ex. 4520Z"`) est dans une string
+  libre qui n'est pas un littéral pur utilisé comme donnée — on cible les
+  `ast.Constant` string dont la valeur *entière* est un code NAF ou un
+  mot-clé sectoriel, ce qui exclut les phrases d'exemple ;
+- un mot sectoriel dans un nom de clé de seed (`'garages'`) n'est pas
+  flaggué car ce n'est pas une donnée de ciblage mais un identifiant.
+
+Limitations assumées (documentées) : le garde-fou ne détecte pas les
+hardcodages construits dynamiquement (concaténation, f-string, variable
+externe). C'est un garde-fou d'alerte, pas une preuve formelle — il rend
+une régression de hardcodage *visible* pour les patterns les plus directs.
+
+Whitelist (valeurs ICP métier légitimes) :
+- `config/icp_seed_example.py` — seed pilote, donnée de test explicite
+- `tests/` — self-référence (les fixtures de test contiennent des NAF)
+- `_bmad/`, `_bmad-output/`, `node_modules`, `.venv`, `docs`, etc.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+# Code NAF français : 4 chiffres + 1 lettre majuscule (valeur entière).
+_NAF_RE = re.compile(r"^\d{4}[A-Z]$")
+
+# Mots-clés sectoriels typiques d'un hardcodage ICP. Inclut les mots-clés
+# positifs/négatifs du seed garages pour qu'une copie en dur dans la logique
+# de production soit détectée. Match sur la valeur entière du littéral.
+_SECTOR_KEYWORDS = {
+    "garage", "garages", "concessionnaire", "concessionnaires",
+    # Mots-clés positifs/négatifs du seed pilote (issue #4) :
+    "réparation", "multi-marques", "atelier",
+    "concession", "groupe", "centrale",
+}
+
+# Répertoires exclus du scan.
+_EXCLUDE_DIRS = {
+    "_bmad", "_bmad-output", "node_modules", ".venv", "venv", ".git",
+    "__pycache__", ".pytest_cache", "docs", "tests",
+}
+# Fichiers exclus (chemins relatifs complets depuis la racine du repo).
+_EXCLUDE_FILES = {Path("config", "icp_seed_example.py")}
+
+
+def _iter_python_files(root: Path):
+    for path in root.rglob("*.py"):
+        rel = path.relative_to(root)
+        if any(part in _EXCLUDE_DIRS for part in path.parts):
+            continue
+        if rel in _EXCLUDE_FILES:
+            continue
+        yield path
+
+
+def _scan(root: Path) -> list[tuple[Path, int, str, str]]:
+    """Retourne (fichier, ligne, valeur, raison) pour chaque valeur métier
+    ICP trouvée comme littéral string entier dans le code.
+
+    Inspecte tout `ast.Constant` string (élément de liste, valeur de
+    retour, valeur de dict, argument de fonction…) dont la valeur entière
+    est un code NAF ou un mot-clé sectoriel.
+    """
+    hits: list[tuple[Path, int, str, str]] = []
+    for path in _iter_python_files(root):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            # Un fichier non parsable n'est pas silencieusement ignoré : on
+            # le signale pour qu'un humain vérifie qu'il ne cache pas du
+            # hardcodage (ex. fichier généré/tronqué).
+            hits.append((path, 0, "<syntax error>", "fichier non parsable"))
+            continue
+        for sub in ast.walk(tree):
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                value = sub.value.strip()
+                if _NAF_RE.match(value):
+                    hits.append((path, sub.lineno, value, "code NAF"))
+                elif value.lower() in _SECTOR_KEYWORDS:
+                    hits.append((path, sub.lineno, value, "mot-clé sectoriel"))
+    return hits
+
+
+def test_no_hardcoded_icp_values():
+    """Aucun code NAF ni mot-clé sectoriel en dur comme littéral string
+    entier dans le code Python de production (hors whitelist)."""
+    root = Path(__file__).resolve().parent.parent
+    hits = _scan(root)
+    if hits:
+        formatted = "\n".join(
+            f"  {p.relative_to(root)}:{lineno} → {raison} '{value}'"
+            for p, lineno, value, raison in hits
+        )
+        pytest.fail(
+            "Valeurs métier ICP codées en dur détectées dans le code Python "
+            f"(hors whitelist) — hardcodage ICP (règle #3) :\n{formatted}\n"
+            "Les valeurs ICP doivent vivre en base (criteres_ciblage) ou "
+            "dans config/icp_seed_example.py (donnée de test), pas dans la "
+            "logique de production."
+        )

--- a/utils/icp_payload.py
+++ b/utils/icp_payload.py
@@ -1,0 +1,178 @@
+"""Modèle de validation d'un payload ICP (Pydantic v2 — règle #7).
+
+Ce module est volontairement découplé de la base de données : il valide et
+normalise une configuration ICP *avant* qu'elle n'atteigne `utils/db.py`.
+Cela permet de tester la logique de validation sans Postgres (tests unitaires
+rapides) et garantit qu'aucune valeur métier n'est insérée en base sans
+passer par les contraintes définies ici.
+
+Colonnes cibles : `criteres_ciblage` + `icp_profiles` (voir
+`docker/postgres/init/01_schema.sql`). Aucune valeur métier codée en dur
+ici (règle #3) — toutes les valeurs proviennent du payload fourni.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Format des codes NAF français : 4 chiffres + 1 lettre majuscule.
+_NAF_RE = re.compile(r"^\d{4}[A-Z]$")
+
+# Départements français : 2 chiffres (01-95), Corse (2A, 2B = 1 chiffre + A/B),
+# ou 3 chiffres pour les DROM/COM (971-988). Refuse 2C, 1A, 99, etc.
+_DEPARTEMENT_RE = re.compile(r"^(\d{2}|2[AB]|\d{3})$")
+
+
+class IcpPayload(BaseModel):
+    """Payload ICP validé, prêt à être inséré en base.
+
+    Représente une configuration de ciblage par client : qui on cherche.
+    Ne contient *aucune* valeur métier par défaut — tout vient de l'appelant
+    (script CLI, fichier seed, ou futur front). Les valeurs « neutres »
+    (effectif_min=1, effectif_max=500) reflètent uniquement les defaults
+    techniques du schéma SQL, pas un ICP métier.
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    # --- Côté client (table `clients`) ---
+    nom_entreprise: str = Field(min_length=1)
+    secteur: str = Field(min_length=1)
+    produit_vendu: str = Field(min_length=1)
+    zone_intervention: str = Field(min_length=1)
+    contact_nom: Optional[str] = None
+    contact_email: Optional[str] = None
+    contact_telephone: Optional[str] = None
+
+    # --- Côté critères de ciblage (table `criteres_ciblage`) ---
+    nom: str = Field(min_length=1)  # nom du critère (ex. "Garages Île-de-France")
+    description_icp: Optional[str] = None
+    codes_naf: tuple[str, ...] = ()
+    departements: tuple[str, ...] = ()
+    effectif_min: int = 1
+    effectif_max: int = 500
+    anciennete_min_ans: int = 0
+    exiger_site_web: bool = False
+    exiger_email: bool = False
+    mots_cles_positifs: tuple[str, ...] = ()
+    mots_cles_negatifs: tuple[str, ...] = ()
+
+    # --- Validateurs ---
+
+    @field_validator("codes_naf", "departements", "mots_cles_positifs",
+                     "mots_cles_negatifs", mode="before")
+    @classmethod
+    def _coerce_tuples(cls, v):
+        """Accepte listes/tuples/chaîne CSV en entrée, stocke en tuple immuable.
+
+        Filtre les entrées vides (cohérent entre CSV et liste JSON) et déduplique
+        en préservant l'ordre de première occurrence.
+        """
+        if v is None:
+            return ()
+        if isinstance(v, str):
+            parts = [part.strip() for part in v.split(",")]
+        else:
+            parts = [str(part).strip() for part in v]
+        # Filtrer les vides + dédupliquer en préservant l'ordre.
+        seen: set[str] = set()
+        out: list[str] = []
+        for p in parts:
+            if p and p not in seen:
+                seen.add(p)
+                out.append(p)
+        return tuple(out)
+
+    @field_validator("codes_naf")
+    @classmethod
+    def _validate_codes_naf(cls, v):
+        # Normalise en majuscules (ergonomie saisie : "4520z" → "4520Z").
+        normalized = tuple(c.upper() for c in v)
+        for code in normalized:
+            if not _NAF_RE.match(code):
+                raise ValueError(
+                    f"Code NAF invalide '{code}' — format attendu : 4 chiffres "
+                    f"suivis d'une lettre majuscule (ex. 4520Z)."
+                )
+        return normalized
+
+    @field_validator("departements")
+    @classmethod
+    def _validate_departements(cls, v):
+        for dep in v:
+            if not _DEPARTEMENT_RE.match(dep):
+                raise ValueError(
+                    f"Département invalide '{dep}' — format attendu : 2 chiffres "
+                    f"(ex. 75), 2A/2B (Corse), ou 3 chiffres (DROM ex. 974)."
+                )
+        return v
+
+    @model_validator(mode="after")
+    def _validate_consistency(self):
+        """Contraintes cross-champs qui ne tiennent pas dans un field_validator."""
+        # Bornes d'effectif : alignées sur le CHECK SQL (effectif_min >= 0).
+        if self.effectif_min < 0:
+            raise ValueError(
+                f"effectif_min ({self.effectif_min}) ne peut pas être négatif."
+            )
+        if self.effectif_max < 0:
+            raise ValueError(
+                f"effectif_max ({self.effectif_max}) ne peut pas être négatif."
+            )
+        if self.effectif_max < self.effectif_min:
+            raise ValueError(
+                f"effectif_max ({self.effectif_max}) < effectif_min "
+                f"({self.effectif_min}) — la borne haute doit être >= borne basse."
+            )
+        if self.anciennete_min_ans < 0:
+            raise ValueError(
+                f"anciennete_min_ans ({self.anciennete_min_ans}) ne peut pas "
+                f"être négatif."
+            )
+        # Un ICP sans aucun critère de ciblage n'a pas de sens : on n'aurait
+        # aucun filtre à appliquer à la source Sirene.
+        if not self.codes_naf and not self.departements:
+            raise ValueError(
+                "Un ICP doit définir au moins un de codes_naf ou departements "
+                "(sinon aucun ciblage n'est possible sur la source Sirene)."
+            )
+        return self
+
+    def to_client_row(self) -> dict:
+        """Dict aligné sur les colonnes NOT NULL de `clients`."""
+        return {
+            "nom_entreprise": self.nom_entreprise,
+            "secteur": self.secteur,
+            "produit_vendu": self.produit_vendu,
+            "zone_intervention": self.zone_intervention,
+            "contact_nom": self.contact_nom,
+            "contact_email": self.contact_email,
+            "contact_telephone": self.contact_telephone,
+        }
+
+    def to_criteres_row(self) -> dict:
+        """Dict aligné sur `criteres_ciblage` (hors client_id / id / timestamps)."""
+        return {
+            "nom": self.nom,
+            "description_icp": self.description_icp,
+            "codes_naf": list(self.codes_naf),
+            "departements": list(self.departements),
+            "effectif_min": self.effectif_min,
+            "effectif_max": self.effectif_max,
+            "anciennete_min_ans": self.anciennete_min_ans,
+            "exiger_site_web": self.exiger_site_web,
+            "exiger_email": self.exiger_email,
+            "mots_cles_positifs": list(self.mots_cles_positifs),
+            "mots_cles_negatifs": list(self.mots_cles_negatifs),
+        }
+
+
+def normalize(payload: dict) -> IcpPayload:
+    """Valide un dict brut et retourne un `IcpPayload` prêt pour la base.
+
+    Lève `pydantic.ValidationError` (avec détails par champ) si le payload
+    ne respecte pas les contraintes. Point d'entrée utilisé par `seed_icp.py`.
+    """
+    return IcpPayload.model_validate(payload)


### PR DESCRIPTION
… garde-fou)

- utils/icp_payload.py : modèle Pydantic v2 validant/normalisant un payload ICP (NAF majuscules, Corse 2A/2B, doublons dédupliqués, effectif négatif rejeté, chaînes required non vides, au moins un ciblage NAF/département).
- config/icp_seed_example.py : seed pilote garages (NAF 4520Z/4511Z/4531Z/ 4532Z, effectif 2-15, ancienneté 3 ans) — donnée de test, pas défaut prod.
- scripts/seed_icp.py : CLI async (argparse + --from-example/--from-file/ --client-id/--dry-run) insérant client+criteres+icp_profile via utils/db.py (upsert applicatif idempotent, re-seed reset qdrant_point_id, erreurs JSON/UUID gérées proprement, single asyncio.run).
- tests/ : 19 tests unitaires (validation + garde-fou anti-hardcodage AST qui échoue si un code NAF/mot-clé sectoriel est codé en dur hors whitelist).

Règle #3 respectée : aucune valeur métier ICP codée en dur dans la logique.