### PR TITLE
feat(#18): enrichissement_agent — cascade Tavily/Crawl4AI/DDG (précision-first)

### DIFF
--- a/agents/enrichissement_agent.py
+++ b/agents/enrichissement_agent.py
@@ -117,9 +117,25 @@ def generic_tokens(criteres: CriteresCiblage | None) -> frozenset[str]:
     return frozenset(tokens)
 
 
+_MIN_TOKEN = 4  # en deçà, un token n'identifie rien (sigles : APF, AK, LS…)
+
+# Un prospect vient de Sirene : il est français. Un ccTLD étranger désigne donc
+# une autre entité — mesuré : `powerup.at` (Autriche) pour une agence parisienne
+# nommée POWER UP, `galeriethomasfischer.de` pour un garage du 8e. Les TLD
+# génériques restent acceptés (une société française peut être en .com/.io).
+_TLD_GENERIQUES = frozenset({
+    "fr", "com", "net", "org", "eu", "io", "ai", "co", "info", "biz", "app", "dev",
+})
+
+
+def _tld_etranger(domain: str) -> bool:
+    tld = domain.rsplit(".", 1)[-1].lower()
+    return len(tld) == 2 and tld not in _TLD_GENERIQUES
+
+
 def _name_tokens(nom: str, generic: frozenset[str]) -> list[str]:
     """Tokens significatifs du nom (sans accents, ≥4 lettres, hors génériques)."""
-    return [t for t in _words(nom) if len(t) >= 4 and t not in generic]
+    return [t for t in _words(nom) if len(t) >= _MIN_TOKEN and t not in generic]
 
 
 def _name_matches_domain(nom: str, domain: str, generic: frozenset[str]) -> bool:
@@ -144,14 +160,19 @@ def _name_matches_domain(nom: str, domain: str, generic: frozenset[str]) -> bool
     Un nom entièrement générique n'est pas confirmable → False (on préfère ne
     rien retenir : un mauvais email est pire que pas d'email).
     """
+    if _tld_etranger(domain):
+        return False
     root = domain.rsplit(".", 1)[0]
     segments = [s for s in re.split(r"[^a-z0-9]+", root) if s]
     if not segments:
         return False
     tokens = _name_tokens(nom, generic)
     # Variantes concaténées du nom : sans les mots génériques, puis avec (un
-    # domaine légitime peut les inclure — `garagedurand.fr`).
-    joints = {"".join(tokens), "".join(_words(nom))} - {""}
+    # domaine légitime peut les inclure — `garagedurand.fr`). Le seuil de
+    # longueur s'applique aussi ici : sans lui, un sigle de 3 lettres passerait
+    # alors qu'il n'a aucun token identifiant (mesuré : « APF » ↔
+    # `apf-francehandicap.org`, une association caritative).
+    joints = {j for j in ("".join(tokens), "".join(_words(nom))) if len(j) >= _MIN_TOKEN}
     candidats = set(segments) | {"".join(segments)}
     return any(t in candidats for t in tokens) or bool(joints & candidats)
 

--- a/agents/enrichissement_agent.py
+++ b/agents/enrichissement_agent.py
@@ -123,12 +123,37 @@ def _name_tokens(nom: str, generic: frozenset[str]) -> list[str]:
 
 
 def _name_matches_domain(nom: str, domain: str, generic: frozenset[str]) -> bool:
-    """Le domaine appartient-il vraisemblablement à l'entreprise ? True si sa
-    racine contient un token significatif du nom. False si le nom est trop
-    générique (on ne peut pas confirmer → on préfère ne rien retenir)."""
-    root = domain.rsplit(".", 1)[0].replace("-", "")
+    """Le domaine appartient-il vraisemblablement à l'entreprise ?
+
+    ⚠️ Le match se fait sur des **mots entiers**, jamais par sous-chaîne. Une
+    comparaison par sous-chaîne (`token in racine`) produit des faux positifs
+    massifs — mesuré sur 15 garages parisiens, 3/3 des contacts « trouvés »
+    appartenaient à une autre société :
+
+        BAYARD AUTOMOBILE  → groupebayard.com      (Bayard Presse, éditeur)
+        AMIN BELFQUIH      → aminkader.com         (marque de mode)
+        AUTONOVA           → autonovamtl.com       (concessionnaire à Montréal)
+        THOMAS FISCHER     → galeriethomasfischer.de (galerie d'art allemande)
+
+    On retient donc un domaine seulement si :
+    - un token significatif du nom **est** un segment du domaine
+      (`durand` ↔ `garage-durand.fr`), ou
+    - le nom concaténé **est** un segment ou la racine entière
+      (`GARAGE DURAND` ↔ `garagedurand.fr`).
+
+    Un nom entièrement générique n'est pas confirmable → False (on préfère ne
+    rien retenir : un mauvais email est pire que pas d'email).
+    """
+    root = domain.rsplit(".", 1)[0]
+    segments = [s for s in re.split(r"[^a-z0-9]+", root) if s]
+    if not segments:
+        return False
     tokens = _name_tokens(nom, generic)
-    return any(t in root or root in t for t in tokens) if tokens else False
+    # Variantes concaténées du nom : sans les mots génériques, puis avec (un
+    # domaine légitime peut les inclure — `garagedurand.fr`).
+    joints = {"".join(tokens), "".join(_words(nom))} - {""}
+    candidats = set(segments) | {"".join(segments)}
+    return any(t in candidats for t in tokens) or bool(joints & candidats)
 
 
 # --- Extraction -------------------------------------------------------------

--- a/agents/enrichissement_agent.py
+++ b/agents/enrichissement_agent.py
@@ -17,6 +17,11 @@ domaine** : on ne retient un email que si son domaine == celui de la page source
 (l'email propre de l'entreprise), et on ne fait confiance aux téléphones d'une
 page que si elle a aussi livré un email au bon domaine.
 
+Ce filtre compare le nom de l'entreprise au domaine, en ignorant les mots qui
+n'identifient personne dans la campagne. Ce vocabulaire non discriminant est
+**dérivé de l'ICP client** (`generic_tokens()`), jamais codé en dur : ce qui est
+générique pour des garages ne l'est pas pour des boulangeries (règle #3).
+
 Architecture pluggable : `RESOLVERS` est une liste ordonnée ; on peut retirer
 Crawl4AI (dépendance lourde) plus tard sans refactor.
 """
@@ -35,6 +40,7 @@ from bs4 import BeautifulSoup
 
 from config.settings import Settings, get_settings
 from graph.state import EtatAgent
+from models.criteres import CriteresCiblage
 from models.prospect import Prospect, _clean_email, _normalize_phone
 
 logger = logging.getLogger(__name__)
@@ -76,27 +82,52 @@ def _email_domain(email: str) -> str:
     return _domain(email.rsplit("@", 1)[-1])
 
 
-# Mots trop génériques pour identifier une entreprise (secteur/forme juridique).
-_GENERIC_TOKENS = frozenset({
-    "garage", "auto", "autos", "automobile", "automobiles", "carrosserie",
-    "mecanique", "reparation", "pieces", "pneus", "pare", "brise", "service",
-    "services", "sarl", "sas", "sasu", "eurl", "sa", "ets", "etablissements",
-    "groupe", "compagnie", "cie", "france", "paris", "societe",
+# Boilerplate de raison sociale : formes juridiques et mentions nationales.
+# Sans rapport avec un secteur — valable pour TOUT ICP, donc légitime en dur.
+# Le vocabulaire non discriminant propre au secteur ciblé, lui, vient de l'ICP
+# client (règle #3) — voir `generic_tokens()`.
+# NB : les tokens < 4 lettres (sas, sa, cie, ets) sont déjà écartés par le
+# seuil de longueur de `_name_tokens`.
+_LEGAL_FORM_TOKENS = frozenset({
+    "sarl", "sasu", "eurl", "etablissements", "societe", "compagnie",
+    "entreprise", "entreprises", "france",
 })
 
 
-def _name_tokens(nom: str) -> list[str]:
+def _words(text: str) -> list[str]:
+    """Mots ASCII minuscules d'un texte (accents retirés)."""
+    n = unicodedata.normalize("NFKD", (text or "").lower()).encode("ascii", "ignore").decode()
+    return [t for t in re.split(r"[^a-z0-9]+", n) if t]
+
+
+def generic_tokens(criteres: CriteresCiblage | None) -> frozenset[str]:
+    """Mots qui n'identifient AUCUNE entreprise dans cette campagne.
+
+    Dans une campagne « garages », tout le monde s'appelle « Garage X » : le mot
+    « garage » ne discrimine personne. Pour une campagne « boulangeries », ce
+    serait « boulangerie ». Ce vocabulaire sectoriel est donc **dérivé de l'ICP
+    client** (`mots_cles_positifs` / `mots_cles_negatifs`, posés dans l'état par
+    `init_campagne` #16) et jamais codé en dur (règle #3). Seul le boilerplate
+    juridique, réellement universel, reste dans le code.
+    """
+    tokens = set(_LEGAL_FORM_TOKENS)
+    if criteres is not None:
+        for mot_cle in (*criteres.mots_cles_positifs, *criteres.mots_cles_negatifs):
+            tokens.update(_words(mot_cle))
+    return frozenset(tokens)
+
+
+def _name_tokens(nom: str, generic: frozenset[str]) -> list[str]:
     """Tokens significatifs du nom (sans accents, ≥4 lettres, hors génériques)."""
-    n = unicodedata.normalize("NFKD", nom.lower()).encode("ascii", "ignore").decode()
-    return [t for t in re.split(r"[^a-z0-9]+", n) if len(t) >= 4 and t not in _GENERIC_TOKENS]
+    return [t for t in _words(nom) if len(t) >= 4 and t not in generic]
 
 
-def _name_matches_domain(nom: str, domain: str) -> bool:
+def _name_matches_domain(nom: str, domain: str, generic: frozenset[str]) -> bool:
     """Le domaine appartient-il vraisemblablement à l'entreprise ? True si sa
     racine contient un token significatif du nom. False si le nom est trop
     générique (on ne peut pas confirmer → on préfère ne rien retenir)."""
     root = domain.rsplit(".", 1)[0].replace("-", "")
-    tokens = _name_tokens(nom)
+    tokens = _name_tokens(nom, generic)
     return any(t in root or root in t for t in tokens) if tokens else False
 
 
@@ -130,7 +161,8 @@ def _extract_from_html(html: str, source_domain: str | None = None) -> tuple[lis
 
 # --- Résolveurs (ordre = cascade) ------------------------------------------
 async def _resolve_tavily(
-    prospect: Prospect, client: httpx.AsyncClient, settings: Settings, site_web: str | None
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings,
+    site_web: str | None, generic: frozenset[str],
 ) -> Contacts | None:
     """Recherche Tavily sur nom+ville ; extrait par résultat en filtrant sur le
     domaine de la page (email propre de l'entreprise). Propose un site candidat."""
@@ -154,7 +186,7 @@ async def _resolve_tavily(
         domain = _domain(url)
         # On n'extrait que des pages dont le domaine matche le nom de l'entreprise
         # (sinon on récupère les contacts d'une AUTRE société).
-        if not _name_matches_domain(prospect.nom_entreprise, domain):
+        if not _name_matches_domain(prospect.nom_entreprise, domain, generic):
             continue
         content = f"{result.get('raw_content') or ''} {result.get('content') or ''}"
         e, p = _extract_from_text(content, source_domain=domain)
@@ -166,7 +198,8 @@ async def _resolve_tavily(
 
 
 async def _resolve_crawl4ai(
-    prospect: Prospect, client: httpx.AsyncClient, settings: Settings, site_web: str | None
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings,
+    site_web: str | None, generic: frozenset[str],
 ) -> Contacts | None:
     """Crawl du site (rendu JS) via Crawl4AI. Dégrade proprement si non installé
     (`crawl4ai-setup` non fait) — la cascade continue sans lui."""
@@ -189,7 +222,8 @@ async def _resolve_crawl4ai(
 
 
 async def _resolve_ddg(
-    prospect: Prospect, client: httpx.AsyncClient, settings: Settings, site_web: str | None
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings,
+    site_web: str | None, generic: frozenset[str],
 ) -> Contacts | None:
     """Dernier recours : recherche DuckDuckGo (sans clé, rate-limité) puis fetch
     httpx des résultats, en filtrant les emails sur le domaine de chaque page."""
@@ -211,7 +245,7 @@ async def _resolve_ddg(
     site = site_web
     for url in [u for u in urls if u][:2]:
         domain = _domain(url)
-        if not _name_matches_domain(prospect.nom_entreprise, domain):
+        if not _name_matches_domain(prospect.nom_entreprise, domain, generic):
             continue
         site = site or url
         try:
@@ -230,16 +264,20 @@ RESOLVERS = [_resolve_tavily, _resolve_crawl4ai, _resolve_ddg]
 
 # --- Enrichissement d'un prospect ------------------------------------------
 async def _enrich_prospect(
-    prospect: Prospect, client: httpx.AsyncClient, settings: Settings
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings,
+    generic: frozenset[str] = frozenset(),
 ) -> None:
     all_emails: list[str] = []
     all_phones: list[str] = []
     sources: list[str] = []
     site = prospect.site_web
+    # La ville n'identifie pas l'entreprise non plus (« Garage de Paris » à
+    # Paris) : on l'ajoute aux tokens non discriminants, prospect par prospect.
+    generic = generic | frozenset(_words(prospect.ville or ""))
 
     for resolver in RESOLVERS:
         try:
-            contacts = await resolver(prospect, client, settings, site)
+            contacts = await resolver(prospect, client, settings, site, generic)
         except Exception as exc:  # un résolveur KO ne casse pas le prospect
             logger.warning("%s KO (%s) : %s", resolver.__name__, prospect.siret, exc)
             continue
@@ -295,11 +333,13 @@ async def enrichissement_node(state: EtatAgent, batch_size: int = BATCH_SIZE) ->
         return state
     settings = get_settings()
     semaphore = asyncio.Semaphore(batch_size)
+    # Vocabulaire non discriminant de CETTE campagne, dérivé de l'ICP client.
+    generic = generic_tokens(state.get("criteres"))
 
     async with httpx.AsyncClient(timeout=20.0) as client:
         async def _one(prospect: Prospect) -> None:
             async with semaphore:
-                await _enrich_prospect(prospect, client, settings)
+                await _enrich_prospect(prospect, client, settings, generic)
 
         await asyncio.gather(*(_one(p) for p in prospects))
 

--- a/agents/enrichissement_agent.py
+++ b/agents/enrichissement_agent.py
@@ -1,12 +1,315 @@
-"""Node LangChain — enrichissement (Tavily + Crawl4AI + Dropcontact).
+"""Node d'enrichissement (#18) — trouve tél/email des prospects collectés.
 
-Issue #11 — STUB. Implémentation détaillée portée par une issue dédiée.
-Sources légales uniquement (règle #2) : Tavily, Pappers, Dropcontact.
-Zéro scraping illégal.
+`sirene_node` (#15) produit des prospects sans contact (Sirene n'en fournit pas).
+Ce node les enrichit via une **cascade de résolveurs** de sources légales
+(règle #2), essayés dans l'ordre jusqu'à trouver un email + un téléphone :
+
+    Tavily (recherche + contenu)  →  Crawl4AI (rendu JS du site)  →  DuckDuckGo
+
+Produit orienté **email-first** (l'appel = Phase 2). La politique email de #10
+est conservée telle quelle (`contact@`/`info@` restent mis à None sur
+`Prospect.email`), MAIS **tous** les contacts bruts trouvés sont stockés dans
+`raw_data['enrichissement']` — terrain de test pour un futur réalignement RGPD.
+
+⚠️ Précision : un email/téléphone glané au hasard dans des résultats de recherche
+appartient souvent à une AUTRE entreprise. On applique donc un **filtre par
+domaine** : on ne retient un email que si son domaine == celui de la page source
+(l'email propre de l'entreprise), et on ne fait confiance aux téléphones d'une
+page que si elle a aussi livré un email au bon domaine.
+
+Architecture pluggable : `RESOLVERS` est une liste ordonnée ; on peut retirer
+Crawl4AI (dépendance lourde) plus tard sans refactor.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from urllib.parse import urlparse
 
-async def enrichissement_node(state: dict) -> dict:
-    """STUB — node d'enrichissement. À implémenter (issue dédiée)."""
-    raise NotImplementedError("enrichissement_agent non implémenté — voir issue dédiée.")
+import httpx
+from bs4 import BeautifulSoup
+
+from config.settings import Settings, get_settings
+from graph.state import EtatAgent
+from models.prospect import Prospect, _clean_email, _normalize_phone
+
+logger = logging.getLogger(__name__)
+
+# Regex fournies par l'issue #18.
+RE_PHONE = re.compile(r"(?:(?:\+33|0033|0)[1-9])(?:[\s.\-]?\d{2}){4}")
+RE_EMAIL = re.compile(r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z]{2,}")
+
+# Extensions d'assets → faux positifs du regex email (ex. `image@2x.png`).
+_ASSET_EXTS = (
+    ".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".tiff",
+    ".css", ".js", ".ico", ".woff", ".woff2",
+)
+
+BATCH_SIZE = 5           # prospects traités en parallèle
+MAX_RAW = 20             # cap des contacts bruts stockés par prospect
+_TAVILY_URL = "https://api.tavily.com/search"
+
+
+@dataclass
+class Contacts:
+    """Résultat brut d'un résolveur (avant validation / politique #10)."""
+    emails: list[str] = field(default_factory=list)
+    phones: list[str] = field(default_factory=list)
+    site_web: str | None = None
+    source: str = ""
+
+
+# --- Domaines ---------------------------------------------------------------
+def _domain(url: str) -> str:
+    """Domaine enregistrable approximatif : `www.garage-x.fr/contact` → `garage-x.fr`."""
+    host = urlparse(url if "//" in url else f"//{url}").netloc.lower().split(":")[0]
+    host = host[4:] if host.startswith("www.") else host
+    parts = host.split(".")
+    return ".".join(parts[-2:]) if len(parts) >= 2 else host
+
+
+def _email_domain(email: str) -> str:
+    return _domain(email.rsplit("@", 1)[-1])
+
+
+# Mots trop génériques pour identifier une entreprise (secteur/forme juridique).
+_GENERIC_TOKENS = frozenset({
+    "garage", "auto", "autos", "automobile", "automobiles", "carrosserie",
+    "mecanique", "reparation", "pieces", "pneus", "pare", "brise", "service",
+    "services", "sarl", "sas", "sasu", "eurl", "sa", "ets", "etablissements",
+    "groupe", "compagnie", "cie", "france", "paris", "societe",
+})
+
+
+def _name_tokens(nom: str) -> list[str]:
+    """Tokens significatifs du nom (sans accents, ≥4 lettres, hors génériques)."""
+    n = unicodedata.normalize("NFKD", nom.lower()).encode("ascii", "ignore").decode()
+    return [t for t in re.split(r"[^a-z0-9]+", n) if len(t) >= 4 and t not in _GENERIC_TOKENS]
+
+
+def _name_matches_domain(nom: str, domain: str) -> bool:
+    """Le domaine appartient-il vraisemblablement à l'entreprise ? True si sa
+    racine contient un token significatif du nom. False si le nom est trop
+    générique (on ne peut pas confirmer → on préfère ne rien retenir)."""
+    root = domain.rsplit(".", 1)[0].replace("-", "")
+    tokens = _name_tokens(nom)
+    return any(t in root or root in t for t in tokens) if tokens else False
+
+
+# --- Extraction -------------------------------------------------------------
+def _extract_from_text(text: str, source_domain: str | None = None) -> tuple[list[str], list[str]]:
+    """Emails/téléphones du texte. Si `source_domain` est fourni, ne garde que les
+    emails de ce domaine (l'email propre de l'entreprise, pas ceux glanés ailleurs)."""
+    emails = [e for e in RE_EMAIL.findall(text or "") if not e.lower().endswith(_ASSET_EXTS)]
+    if source_domain:
+        emails = [e for e in emails if _email_domain(e) == source_domain]
+    return emails, RE_PHONE.findall(text or "")
+
+
+def _extract_from_html(html: str, source_domain: str | None = None) -> tuple[list[str], list[str]]:
+    """Emails via `mailto:` (fiable) + regex ; téléphones via regex. Filtre domaine."""
+    mailtos: list[str] = []
+    try:
+        soup = BeautifulSoup(html or "", "html.parser")
+        for a in soup.select('a[href^="mailto:"]'):
+            addr = a.get("href", "")[len("mailto:"):].split("?")[0].strip()
+            if addr:
+                mailtos.append(addr)
+        text = soup.get_text(" ")
+    except Exception:  # HTML malformé → on retombe sur le brut
+        text = html or ""
+    if source_domain:
+        mailtos = [m for m in mailtos if _email_domain(m) == source_domain]
+    e, phones = _extract_from_text(text, source_domain)
+    return mailtos + e, phones
+
+
+# --- Résolveurs (ordre = cascade) ------------------------------------------
+async def _resolve_tavily(
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings, site_web: str | None
+) -> Contacts | None:
+    """Recherche Tavily sur nom+ville ; extrait par résultat en filtrant sur le
+    domaine de la page (email propre de l'entreprise). Propose un site candidat."""
+    if not settings.tavily_api_key:
+        return None
+    query = f"{prospect.nom_entreprise} {prospect.ville or ''} contact email".strip()
+    resp = await client.post(
+        _TAVILY_URL,
+        headers={"Authorization": f"Bearer {settings.tavily_api_key}"},
+        json={"query": query, "include_raw_content": True, "max_results": 5},
+    )
+    logger.info("Tavily +1 (quota 1000/mois, #23) — %s", prospect.siret)
+    resp.raise_for_status()
+    data = resp.json()
+
+    emails: list[str] = []
+    phones: list[str] = []
+    candidate_site = site_web
+    for result in data.get("results", []):
+        url = result.get("url", "")
+        domain = _domain(url)
+        # On n'extrait que des pages dont le domaine matche le nom de l'entreprise
+        # (sinon on récupère les contacts d'une AUTRE société).
+        if not _name_matches_domain(prospect.nom_entreprise, domain):
+            continue
+        content = f"{result.get('raw_content') or ''} {result.get('content') or ''}"
+        e, p = _extract_from_text(content, source_domain=domain)
+        emails += e
+        phones += p  # page confirmée = l'entreprise → son tél est fiable
+        if candidate_site is None and url:
+            candidate_site = url
+    return Contacts(emails, phones, candidate_site, "tavily")
+
+
+async def _resolve_crawl4ai(
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings, site_web: str | None
+) -> Contacts | None:
+    """Crawl du site (rendu JS) via Crawl4AI. Dégrade proprement si non installé
+    (`crawl4ai-setup` non fait) — la cascade continue sans lui."""
+    if not site_web:
+        return None
+    try:
+        from crawl4ai import AsyncWebCrawler
+    except ImportError:
+        logger.info("crawl4ai non installé — résolveur ignoré")
+        return None
+    try:
+        async with AsyncWebCrawler(verbose=False) as crawler:
+            result = await crawler.arun(url=site_web)
+        html = getattr(result, "html", None) or getattr(result, "cleaned_html", "") or ""
+    except Exception as exc:
+        logger.warning("crawl4ai KO (%s) : %s", site_web, exc)
+        return None
+    emails, phones = _extract_from_html(html, source_domain=_domain(site_web))
+    return Contacts(emails, phones, site_web, "crawl4ai")
+
+
+async def _resolve_ddg(
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings, site_web: str | None
+) -> Contacts | None:
+    """Dernier recours : recherche DuckDuckGo (sans clé, rate-limité) puis fetch
+    httpx des résultats, en filtrant les emails sur le domaine de chaque page."""
+    query = f"{prospect.nom_entreprise} {prospect.ville or ''}".strip()
+
+    def _search() -> list[str]:
+        from ddgs import DDGS
+        with DDGS() as ddgs:
+            return [r.get("href") for r in ddgs.text(query, max_results=3)]
+
+    try:
+        urls = await asyncio.to_thread(_search)
+    except Exception as exc:
+        logger.info("ddgs KO (%s) : %s", prospect.siret, exc)
+        return None
+
+    emails: list[str] = []
+    phones: list[str] = []
+    site = site_web
+    for url in [u for u in urls if u][:2]:
+        domain = _domain(url)
+        if not _name_matches_domain(prospect.nom_entreprise, domain):
+            continue
+        site = site or url
+        try:
+            resp = await client.get(url, timeout=15.0, follow_redirects=True)
+            e, p = _extract_from_html(resp.text, source_domain=domain)
+            emails += e
+            phones += p
+        except Exception:
+            continue
+        await asyncio.sleep(1.0)  # throttle DDG
+    return Contacts(emails, phones, site, "ddg")
+
+
+RESOLVERS = [_resolve_tavily, _resolve_crawl4ai, _resolve_ddg]
+
+
+# --- Enrichissement d'un prospect ------------------------------------------
+async def _enrich_prospect(
+    prospect: Prospect, client: httpx.AsyncClient, settings: Settings
+) -> None:
+    all_emails: list[str] = []
+    all_phones: list[str] = []
+    sources: list[str] = []
+    site = prospect.site_web
+
+    for resolver in RESOLVERS:
+        try:
+            contacts = await resolver(prospect, client, settings, site)
+        except Exception as exc:  # un résolveur KO ne casse pas le prospect
+            logger.warning("%s KO (%s) : %s", resolver.__name__, prospect.siret, exc)
+            continue
+        if contacts is None:
+            continue
+        all_emails += contacts.emails
+        all_phones += contacts.phones
+        sources.append(contacts.source)
+        if contacts.site_web and not site:
+            site = contacts.site_web
+        if all_emails and all_phones:  # email + tél trouvés → stop
+            break
+
+    all_emails = list(dict.fromkeys(all_emails))[:MAX_RAW]
+    all_phones = list(dict.fromkeys(all_phones))[:MAX_RAW]
+
+    # Politique #10 conservée : validators (email générique → None) via les
+    # helpers réutilisés. On garde le 1er contact valide.
+    if prospect.email is None:
+        for raw in all_emails:
+            cleaned = _clean_email(raw)
+            if cleaned:
+                prospect.email = cleaned
+                break
+    if prospect.telephone is None:
+        for raw in all_phones:
+            norm = _normalize_phone(raw)
+            if norm:
+                prospect.telephone = norm
+                break
+    if site and not prospect.site_web:
+        prospect.site_web = site
+
+    # Terrain de test pour le réalignement RGPD : on garde TOUT le brut trouvé
+    # (y compris les emails génériques que la politique #10 a mis à None).
+    prospect.raw_data = {
+        **(prospect.raw_data or {}),
+        "enrichissement": {
+            "emails": all_emails,
+            "phones_raw": all_phones,
+            "site_web": site,
+            "sources": sources,
+            "at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+
+
+# --- Node -------------------------------------------------------------------
+async def enrichissement_node(state: EtatAgent, batch_size: int = BATCH_SIZE) -> EtatAgent:
+    """Enrichit `state['prospects']` en tél/email via la cascade. Batch parallèle."""
+    prospects: list[Prospect] = state.get("prospects", [])
+    if not prospects:
+        return state
+    settings = get_settings()
+    semaphore = asyncio.Semaphore(batch_size)
+
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        async def _one(prospect: Prospect) -> None:
+            async with semaphore:
+                await _enrich_prospect(prospect, client, settings)
+
+        await asyncio.gather(*(_one(p) for p in prospects))
+
+    with_email = sum(1 for p in prospects if p.email)
+    with_phone = sum(1 for p in prospects if p.telephone)
+    total = len(prospects)
+    logger.info(
+        "enrichissement : email %d/%d (%.0f%%), tél %d/%d (%.0f%%)",
+        with_email, total, 100 * with_email / total,
+        with_phone, total, 100 * with_phone / total,
+    )
+    state["prospects"] = prospects
+    return state

--- a/agents/enrichissement_agent.py
+++ b/agents/enrichissement_agent.py
@@ -22,8 +22,13 @@ n'identifient personne dans la campagne. Ce vocabulaire non discriminant est
 **dérivé de l'ICP client** (`generic_tokens()`), jamais codé en dur : ce qui est
 générique pour des garages ne l'est pas pour des boulangeries (règle #3).
 
-Architecture pluggable : `RESOLVERS` est une liste ordonnée ; on peut retirer
-Crawl4AI (dépendance lourde) plus tard sans refactor.
+Architecture pluggable : `RESOLVERS` est une liste ordonnée.
+
+Crawl4AI est **optionnel et absent de `requirements.txt`** (voir
+`requirements-optional.txt`) : mesuré sur 20 domaines vérifiés, il n'apporte qu'un
+email de plus que httpx, pour 2× le temps — et il ne s'installe pas sous Windows.
+Le résolveur ci-dessous dégrade silencieusement si l'import échoue, donc la cascade
+fonctionne à l'identique avec ou sans lui.
 """
 from __future__ import annotations
 

--- a/config/icp_seed_example.py
+++ b/config/icp_seed_example.py
@@ -44,7 +44,15 @@ ICP_SEEDS: dict[str, dict] = {
         "anciennete_min_ans": 3,
         "exiger_site_web": False,
         "exiger_email": True,
-        "mots_cles_positifs": ["réparation", "multi-marques", "atelier"],
+        # Vocabulaire sectoriel de la cible. Sert deux usages : signaux positifs
+        # du scoring règles (#24) ET mots non discriminants pour le filtre
+        # nom↔domaine de l'enrichissement (#18) — dans une campagne garages,
+        # « garage » ne distingue aucun prospect d'un autre.
+        "mots_cles_positifs": [
+            "réparation", "multi-marques", "atelier", "garage", "auto",
+            "automobile", "carrosserie", "mécanique", "pièces", "pneus",
+            "pare-brise", "service",
+        ],
         "mots_cles_negatifs": ["concession", "groupe", "centrale"],
     },
 }

--- a/config/icp_seed_example.py
+++ b/config/icp_seed_example.py
@@ -34,10 +34,17 @@ ICP_SEEDS: dict[str, dict] = {
             "de 2 à 15 salariés, en activité depuis au moins 3 ans. Ciblent "
             "les réparateurs multi-marques plutôt que les concessions."
         ),
-        # Codes NAF : réparation auto (4520Z), vente auto (4511Z),
-        # réparation moto (4540Z — non inclus, hors cible), entretien/carrosserie
-        # (4531Z), installation équipements auto (4532Z).
-        "codes_naf": ["4520Z", "4511Z", "4531Z", "4532Z"],
+        # Codes NAF (issue #63) : `4520Z` N'EXISTE PAS. 4520 est une *classe*,
+        # subdivisée en deux sous-classes — seules celles-ci sont portées par les
+        # établissements Sirene :
+        #   4520A entretien/réparation de véhicules légers (2 971 actifs à Paris)
+        #   4520B entretien/réparation d'autres véhicules   (116 actifs à Paris)
+        # Interroger `45.20Z` renvoie HTTP 404, que `_fetch_etablissements` traite
+        # comme « aucun résultat » : la collecte était donc silencieusement vide
+        # sur le code de ciblage principal, sans la moindre erreur visible.
+        # Autres codes : vente auto (4511Z), entretien/carrosserie (4531Z),
+        # installation d'équipements auto (4532Z). Réparation moto (4540Z) hors cible.
+        "codes_naf": ["4520A", "4520B", "4511Z", "4531Z", "4532Z"],
         "departements": [],  # pas de restriction géo dans l'exemple pilote
         "effectif_min": 2,
         "effectif_max": 15,

--- a/config/settings.py
+++ b/config/settings.py
@@ -42,6 +42,7 @@ class Settings(BaseSettings):
 
     # ---------- APIs collecte ----------
     insee_api_key: str = ""  # api-sirene/3.11 (header X-INSEE-Api-Key-Integration)
+    tavily_api_key: str = ""  # enrichissement (#18) — auth Bearer, quota 1000/mois
 
     @property
     def postgres_dsn(self) -> str:

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,30 @@
+# Dépendances OPTIONNELLES — n'installer que sur le VPS Linux de production.
+#
+# Rien ici n'est nécessaire pour faire tourner le pipeline ni les tests : le code
+# dégrade silencieusement si l'import échoue.
+#
+#   pip install -r requirements-optional.txt
+#
+# ---------------------------------------------------------------------------
+# crawl4ai — rendu JS d'un site, en DERNIER RECOURS
+# ---------------------------------------------------------------------------
+# Mesuré sur 20 domaines vérifiés par la jointure géographique OSM (#69), mêmes
+# chemins comparés avec httpx :
+#   → 1 email trouvé sur 20 que httpx n'avait pas (`hotel@hoteldudragon.com`)
+#   → 19/20 résultats identiques, pour 2× le temps
+# Soit ~5 % des domaines, +2,5 points de bout en bout. Réel, mais marginal.
+# (Un premier test sur 7 domaines suggérait ~14 % : l'échantillon plus large a
+#  divisé le gain par trois — d'où la prudence.)
+#
+# ⚠️ NE S'INSTALLE PAS SOUS WINDOWS depuis un clone propre : `pip install
+# crawl4ai` échoue avec `OSError` (limite MAX_PATH de 260 caractères, atteinte en
+# dépaquetant `litellm/proxy/_experimental/...`). Le contournement `--no-deps` ne
+# marche qu'après un premier essai échoué. Sur Linux le problème n'existe pas —
+# d'où l'installation réservée au VPS.
+#
+# ⚠️ Ne résout PAS les protections anti-bot : bloqué par le challenge JS de
+# Cloudflare lors du test.
+#
+# Coût : ~2 Go avec Chromium, 65 paquets supplémentaires.
+# Après installation : `python -m playwright install chromium`
+crawl4ai>=0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,11 @@ phonenumbers>=8.13            # normalisation téléphone -> E.164
 email-validator>=2.1          # validation email RFC (utilisé par le validator, pas EmailStr)
 python-stdnum>=1.19           # SIRET/SIREN : checksum Luhn + exception La Poste
 
+# Enrichissement (issue #18) — cascade Tavily (via httpx) + Crawl4AI + DuckDuckGo
+beautifulsoup4>=4.12          # extraction mailto/emails du HTML
+ddgs>=6.0                     # DuckDuckGo (fallback recherche, sans clé)
+crawl4ai>=0.4                 # crawl JS (Playwright) — nécessite `crawl4ai-setup`
+
 # --- Dev (tests) ---
 pytest>=8.0,<9.0
 pytest-asyncio>=0.23,<0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,10 @@ phonenumbers>=8.13            # normalisation téléphone -> E.164
 email-validator>=2.1          # validation email RFC (utilisé par le validator, pas EmailStr)
 python-stdnum>=1.19           # SIRET/SIREN : checksum Luhn + exception La Poste
 
-# Enrichissement (issue #18) — cascade Tavily (via httpx) + Crawl4AI + DuckDuckGo
+# Enrichissement (issue #18) — cascade Tavily (via httpx) + DuckDuckGo
 beautifulsoup4>=4.12          # extraction mailto/emails du HTML
 ddgs>=6.0                     # DuckDuckGo (fallback recherche, sans clé)
-crawl4ai>=0.4                 # crawl JS (Playwright) — nécessite `crawl4ai-setup`
+# crawl4ai : volontairement ABSENT — voir requirements-optional.txt
 
 # --- Dev (tests) ---
 pytest>=8.0,<9.0

--- a/tests/test_enrichissement.py
+++ b/tests/test_enrichissement.py
@@ -176,6 +176,25 @@ def test_rejects_measured_false_positives(nom, domaine, quoi):
     assert not ea._name_matches_domain(nom, domaine, GARAGES), f"{domaine} = {quoi}"
 
 
+def test_sigle_trop_court_ne_matche_pas():
+    """Mesuré sur l'ICP agences : « APF » (3 lettres, aucun token identifiant)
+    matchait `apf-francehandicap.org` — une association caritative — via la
+    variante concaténée du nom, qui contournait le seuil de longueur."""
+    agences = ea.generic_tokens(_criteres(["agence", "communication"]))
+    assert not ea._name_matches_domain("APF", "apf-francehandicap.org", agences)
+    assert not ea._name_matches_domain("AK", "akillis.com", agences)
+
+
+def test_tld_etranger_rejete():
+    """Un prospect Sirene est français : un ccTLD étranger = autre entité."""
+    agences = ea.generic_tokens(_criteres(["agence", "communication"]))
+    assert not ea._name_matches_domain("POWER UP", "powerup.at", agences)
+    assert not ea._name_matches_domain("THOMAS FISCHER", "thomasfischer.de", GARAGES)
+    # les TLD génériques restent acceptés
+    assert ea._name_matches_domain("THEMIO", "themio.ai", GARAGES)
+    assert ea._name_matches_domain("GARAGE DURAND", "garagedurand.fr", GARAGES)
+
+
 def test_substring_alone_is_never_enough():
     """Un token inclus dans la racine sans en être un mot entier → rejet."""
     assert not ea._name_matches_domain("MARTIN", "martinelli-immobilier.fr", GARAGES)

--- a/tests/test_enrichissement.py
+++ b/tests/test_enrichissement.py
@@ -18,6 +18,7 @@ from agents.enrichissement_agent import (
     _extract_from_text,
     enrichissement_node,
 )
+from models.criteres import CriteresCiblage
 from models.prospect import Prospect
 
 CID = uuid.uuid4()
@@ -28,7 +29,7 @@ def _p(**over) -> Prospect:
 
 
 def _fixed_resolver(contacts: Contacts, log: list | None = None, name: str = ""):
-    async def _resolver(prospect, client, settings, site_web):
+    async def _resolver(prospect, client, settings, site_web, generic):
         if log is not None:
             log.append(name)
         return contacts
@@ -122,14 +123,65 @@ async def test_node_empty_prospects_noop():
     assert (await enrichissement_node({"prospects": []}))["prospects"] == []
 
 
+# --- Vocabulaire non discriminant dérivé de l'ICP (règle #3) ----------------
+def _criteres(positifs: list[str], negatifs: list[str] | None = None) -> CriteresCiblage:
+    return CriteresCiblage(
+        nom="ICP de test",
+        mots_cles_positifs=positifs,
+        mots_cles_negatifs=negatifs or [],
+    )
+
+
+# ICP pilote « garages » : son vocabulaire sectoriel n'identifie aucun prospect.
+GARAGES = ea.generic_tokens(_criteres(["garage", "auto", "pare-brise"], ["groupe"]))
+
+
+def test_generic_tokens_come_from_icp_not_code():
+    assert "garage" in GARAGES and "brise" in GARAGES     # mots-clés ICP
+    assert "sarl" in GARAGES                              # boilerplate juridique
+    # Rien de sectoriel n'est présent sans l'ICP correspondant.
+    assert "garage" not in ea.generic_tokens(None)
+    # Un autre ICP → un autre vocabulaire générique.
+    boulangeries = ea.generic_tokens(_criteres(["boulangerie", "patisserie"]))
+    assert "boulangerie" in boulangeries and "garage" not in boulangeries
+
+
 # --- Filtre de précision (page = bonne entreprise) --------------------------
 def test_name_matches_domain():
-    assert ea._name_matches_domain("Garagex Pro", "garagex.fr")
-    assert ea._name_matches_domain("BAYARD AUTOMOBILE", "groupe-bayard.com")
-    assert not ea._name_matches_domain("INTEGRAL PARE BRISE", "carygroup.com")
-    assert not ea._name_matches_domain("XAVIER SUZZONI", "essec.edu")
-    # nom trop générique → non confirmable → False (on préfère ne rien retenir)
-    assert not ea._name_matches_domain("Garage Auto", "unsite.fr")
+    assert ea._name_matches_domain("Garagex Pro", "garagex.fr", GARAGES)
+    assert ea._name_matches_domain("BAYARD AUTOMOBILE", "groupe-bayard.com", GARAGES)
+    assert not ea._name_matches_domain("INTEGRAL PARE BRISE", "carygroup.com", GARAGES)
+    assert not ea._name_matches_domain("XAVIER SUZZONI", "essec.edu", GARAGES)
+    # nom 100 % sectoriel → non confirmable → False (on préfère ne rien retenir)
+    assert not ea._name_matches_domain("Garage Auto", "garage-auto-durand.fr", GARAGES)
+
+
+def test_name_match_depends_on_the_campaign_icp():
+    """Le même nom est discriminant ou non selon l'ICP de la campagne."""
+    nom, domaine = "Garage Durand", "garage-martin.fr"
+    # Campagne garages : « garage » ne discrimine pas → seul « durand » compte
+    # → le domaine du garage Martin est bien rejeté.
+    assert not ea._name_matches_domain(nom, domaine, GARAGES)
+    # Campagne boulangeries : « garage » redevient un token identifiant → match.
+    assert ea._name_matches_domain(nom, domaine, ea.generic_tokens(_criteres(["boulangerie"])))
+
+
+@pytest.mark.asyncio
+async def test_node_derives_generic_tokens_from_state_criteres(monkeypatch):
+    """Le node passe bien le vocabulaire de l'ICP aux résolveurs."""
+    seen: list[frozenset[str]] = []
+
+    async def _resolver(prospect, client, settings, site_web, generic):
+        seen.append(generic)
+        return Contacts(source="spy")
+
+    monkeypatch.setattr(ea, "RESOLVERS", [_resolver])
+    await enrichissement_node({
+        "prospects": [_p()],
+        "criteres": _criteres(["garage", "atelier"]),
+    })
+    assert "garage" in seen[0] and "atelier" in seen[0]
+    assert "paris" in seen[0]  # la ville du prospect n'identifie personne non plus
 
 
 # --- Résolveur Tavily (HTTP mocké) -----------------------------------------
@@ -143,7 +195,7 @@ async def test_tavily_resolver_extracts_when_domain_matches_name():
     prospect = Prospect(campagne_id=CID, nom_entreprise="Garagex Pro", ville="Paris")
     settings = ea.Settings(tavily_api_key="test-key")
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        contacts = await ea._resolve_tavily(prospect, client, settings, None)
+        contacts = await ea._resolve_tavily(prospect, client, settings, None, GARAGES)
     assert contacts.emails == ["pro@garagex.fr"]           # essec.edu écarté
     assert contacts.site_web == "http://garagex.fr"
     assert contacts.phones                                 # tél de la page confirmée

--- a/tests/test_enrichissement.py
+++ b/tests/test_enrichissement.py
@@ -1,0 +1,149 @@
+"""Tests unitaires du node d'enrichissement (#18).
+
+Couvre l'extraction (regex + mailto + filtre faux positifs), la politique #10
+conservée (email générique gardé dans raw_data mais None sur `.email`), l'ordre
+de cascade (stop dès email+tél) et le batch. HTTP mocké — aucune vraie API.
+"""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from agents import enrichissement_agent as ea
+from agents.enrichissement_agent import (
+    Contacts,
+    _extract_from_html,
+    _extract_from_text,
+    enrichissement_node,
+)
+from models.prospect import Prospect
+
+CID = uuid.uuid4()
+
+
+def _p(**over) -> Prospect:
+    return Prospect(campagne_id=CID, nom_entreprise="Garage Test", ville="Paris", **over)
+
+
+def _fixed_resolver(contacts: Contacts, log: list | None = None, name: str = ""):
+    async def _resolver(prospect, client, settings, site_web):
+        if log is not None:
+            log.append(name)
+        return contacts
+    return _resolver
+
+
+# --- Extraction -------------------------------------------------------------
+def test_extract_from_text_email_and_phone():
+    emails, phones = _extract_from_text("Écrire à jean.dupont@garage-x.fr ou 01 42 55 66 77")
+    assert "jean.dupont@garage-x.fr" in emails
+    assert phones and "42" in phones[0]
+
+
+def test_extract_filters_asset_false_positives():
+    emails, _ = _extract_from_text("logo image@2x.png sprite@3x.jpg mais vrai@site.fr")
+    assert emails == ["vrai@site.fr"]
+
+
+def test_extract_from_html_prefers_mailto():
+    html = '<a href="mailto:contact@garage.fr?subject=x">Nous écrire</a> — tél 06 12 34 56 78'
+    emails, phones = _extract_from_html(html)
+    assert "contact@garage.fr" in emails
+    assert phones  # 06 12 34 56 78 capturé
+
+
+# --- Politique #10 conservée -----------------------------------------------
+@pytest.mark.asyncio
+async def test_valid_contact_set_on_prospect(monkeypatch):
+    monkeypatch.setattr(ea, "RESOLVERS", [_fixed_resolver(
+        Contacts(emails=["jean.dupont@garage-x.fr"], phones=["0612345678"],
+                 site_web="http://garage-x.fr", source="tavily")
+    )])
+    p = _p()
+    await ea._enrich_prospect(p, None, ea.get_settings())
+    assert p.email == "jean.dupont@garage-x.fr"
+    assert p.telephone == "+33612345678"      # normalisé E.164
+    assert p.site_web == "http://garage-x.fr"
+    assert p.raw_data["enrichissement"]["sources"] == ["tavily"]
+
+
+@pytest.mark.asyncio
+async def test_generic_email_kept_in_rawdata_but_nulled(monkeypatch):
+    # contact@ : politique #10 -> None sur .email, MAIS gardé dans raw_data.
+    monkeypatch.setattr(ea, "RESOLVERS", [_fixed_resolver(
+        Contacts(emails=["contact@garage.fr"], phones=[], source="tavily")
+    )])
+    p = _p()
+    await ea._enrich_prospect(p, None, ea.get_settings())
+    assert p.email is None
+    assert "contact@garage.fr" in p.raw_data["enrichissement"]["emails"]
+
+
+# --- Cascade ----------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_cascade_stops_when_email_and_phone_found(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(ea, "RESOLVERS", [
+        _fixed_resolver(Contacts(emails=["a@b.fr"], phones=["0612345678"], source="r1"), log, "r1"),
+        _fixed_resolver(Contacts(emails=["c@d.fr"], phones=["0698765432"], source="r2"), log, "r2"),
+    ])
+    await ea._enrich_prospect(_p(), None, ea.get_settings())
+    assert log == ["r1"]  # r2 jamais appelé
+
+
+@pytest.mark.asyncio
+async def test_cascade_falls_through_when_first_empty(monkeypatch):
+    log: list[str] = []
+    monkeypatch.setattr(ea, "RESOLVERS", [
+        _fixed_resolver(Contacts(source="r1"), log, "r1"),  # rien
+        _fixed_resolver(Contacts(emails=["x@y.fr"], phones=["0612345678"], source="r2"), log, "r2"),
+    ])
+    p = _p()
+    await ea._enrich_prospect(p, None, ea.get_settings())
+    assert log == ["r1", "r2"]
+    assert p.email == "x@y.fr"
+
+
+# --- Node (batch) -----------------------------------------------------------
+@pytest.mark.asyncio
+async def test_node_enriches_batch(monkeypatch):
+    monkeypatch.setattr(ea, "RESOLVERS", [_fixed_resolver(
+        Contacts(emails=["x@y.fr"], phones=["0612345678"], source="tavily")
+    )])
+    state = {"prospects": [_p(), _p(), _p()]}
+    out = await enrichissement_node(state, batch_size=2)
+    assert all(p.email == "x@y.fr" and p.telephone == "+33612345678" for p in out["prospects"])
+
+
+@pytest.mark.asyncio
+async def test_node_empty_prospects_noop():
+    assert (await enrichissement_node({"prospects": []}))["prospects"] == []
+
+
+# --- Filtre de précision (page = bonne entreprise) --------------------------
+def test_name_matches_domain():
+    assert ea._name_matches_domain("Garagex Pro", "garagex.fr")
+    assert ea._name_matches_domain("BAYARD AUTOMOBILE", "groupe-bayard.com")
+    assert not ea._name_matches_domain("INTEGRAL PARE BRISE", "carygroup.com")
+    assert not ea._name_matches_domain("XAVIER SUZZONI", "essec.edu")
+    # nom trop générique → non confirmable → False (on préfère ne rien retenir)
+    assert not ea._name_matches_domain("Garage Auto", "unsite.fr")
+
+
+# --- Résolveur Tavily (HTTP mocké) -----------------------------------------
+@pytest.mark.asyncio
+async def test_tavily_resolver_extracts_when_domain_matches_name():
+    def handler(request):
+        return httpx.Response(200, json={"results": [
+            {"url": "http://essec.edu", "raw_content": "pavie@essec.edu"},          # autre entité → rejeté
+            {"url": "http://garagex.fr", "raw_content": "pro@garagex.fr — 01 42 55 66 77"},
+        ]})
+    prospect = Prospect(campagne_id=CID, nom_entreprise="Garagex Pro", ville="Paris")
+    settings = ea.Settings(tavily_api_key="test-key")
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        contacts = await ea._resolve_tavily(prospect, client, settings, None)
+    assert contacts.emails == ["pro@garagex.fr"]           # essec.edu écarté
+    assert contacts.site_web == "http://garagex.fr"
+    assert contacts.phones                                 # tél de la page confirmée

--- a/tests/test_enrichissement.py
+++ b/tests/test_enrichissement.py
@@ -149,11 +149,37 @@ def test_generic_tokens_come_from_icp_not_code():
 # --- Filtre de précision (page = bonne entreprise) --------------------------
 def test_name_matches_domain():
     assert ea._name_matches_domain("Garagex Pro", "garagex.fr", GARAGES)
-    assert ea._name_matches_domain("BAYARD AUTOMOBILE", "groupe-bayard.com", GARAGES)
+    # token significatif == segment du domaine
+    assert ea._name_matches_domain("GARAGE DURAND", "garage-durand.fr", GARAGES)
+    # nom concaténé == racine (domaine sans tiret)
+    assert ea._name_matches_domain("GARAGE DURAND", "garagedurand.fr", GARAGES)
     assert not ea._name_matches_domain("INTEGRAL PARE BRISE", "carygroup.com", GARAGES)
     assert not ea._name_matches_domain("XAVIER SUZZONI", "essec.edu", GARAGES)
     # nom 100 % sectoriel → non confirmable → False (on préfère ne rien retenir)
     assert not ea._name_matches_domain("Garage Auto", "garage-auto-durand.fr", GARAGES)
+
+
+@pytest.mark.parametrize("nom,domaine,quoi", [
+    ("BAYARD AUTOMOBILE", "groupebayard.com", "Bayard Presse, éditeur"),
+    ("AMIN BELFQUIH", "aminkader.com", "marque de mode"),
+    ("AUTONOVA", "autonovamtl.com", "concessionnaire à Montréal"),
+    ("THOMAS FISCHER", "galeriethomasfischer.de", "galerie d'art allemande"),
+])
+def test_rejects_measured_false_positives(nom, domaine, quoi):
+    """Non-régression : faux positifs réels mesurés sur 15 garages parisiens.
+
+    Tous passaient avec l'ancien match par sous-chaîne (`bayard` ⊂ `groupebayard`).
+    Le pire d'entre eux livrait `dpo@groupebayard.com` — le délégué à la
+    protection des données d'un éditeur, soit le pire destinataire possible
+    pour de la prospection à froid.
+    """
+    assert not ea._name_matches_domain(nom, domaine, GARAGES), f"{domaine} = {quoi}"
+
+
+def test_substring_alone_is_never_enough():
+    """Un token inclus dans la racine sans en être un mot entier → rejet."""
+    assert not ea._name_matches_domain("MARTIN", "martinelli-immobilier.fr", GARAGES)
+    assert not ea._name_matches_domain("NOVA", "novatech-solutions.com", GARAGES)
 
 
 def test_name_match_depends_on_the_campaign_icp():


### PR DESCRIPTION
## Contexte

`enrichissement_node(state)` enrichit en tél/email les prospects de `sirene_node`
(#15, sans contact). Cascade de résolveurs **pluggables** (Tavily → Crawl4AI
[optionnel] → DDG), batch 5 parallèle. Produit **email-first**. Convention
`*_node(state)`.

> ⚠️ **À lire avant de reviewer.** Cette PR livre un node fonctionnel **et un
> résultat négatif mesuré** : l'enrichissement par recherche de nom **ne marche pas**
> sur des garages français de petite taille. Ce n'est pas un bug à corriger avant
> merge — c'est la conclusion, documentée ci-dessous, et elle change la priorité de
> la suite du sprint.

---

## 1. Précision d'abord : un mauvais email est pire que pas d'email

Un email/tél glané dans des résultats de recherche appartient souvent à une **autre**
société. On ne retient donc un contact que si la page vient d'un domaine **confirmé**
comme appartenant à l'entreprise, que le domaine de l'email == celui de la page, et
hors faux positifs d'assets (`image@2x.png`).

Ce principe n'a jamais été remis en cause. C'est son **implémentation** qui était
fausse (§2).

## 2. Le filtre de précision était cassé — mesuré, pas supposé

Le filtre comparait le nom au domaine **par sous-chaîne** (`any(token in racine)`).
Sur 15 garages parisiens, **3 contacts « trouvés » sur 3 appartenaient à une autre
société** :

| Prospect (garage Paris) | Domaine retenu | Ce que c'est réellement |
|---|---|---|
| BAYARD AUTOMOBILE | `groupebayard.com` | **Bayard Presse**, éditeur |
| AMIN BELFQUIH | `aminkader.com` | marque de mode |
| AUTONOVA | `autonovamtl.com` | concessionnaire à **Montréal** |
| THOMAS FISCHER | `galeriethomasfischer.de` | galerie d'art allemande |

`bayard` ⊂ `groupebayard`, `amin` ⊂ `aminkader`, `autonova` ⊂ `autonovamtl` : un
token de 4+ lettres inclus dans une racine plus longue matche à peu près n'importe
quoi. Le filtre email-domaine==page-domaine ne peut rien y faire — la page est
cohérente avec elle-même, c'est juste la mauvaise entreprise.

**Le seul email que le pipeline aurait livré à un commercial était
`dpo@groupebayard.com`** — le délégué à la protection des données d'un éditeur, soit
le pire destinataire imaginable pour de la prospection à froid. `_clean_email` (#10)
neutralise `contact@`/`info@` mais pas `dpo@`.

Aggravant : **le test unitaire validait le bug** (`BAYARD AUTOMOBILE` ↔
`groupe-bayard.com` attendu `True`). Corrigé ; les 4 faux positifs réels sont
désormais des tests de non-régression.

**Correctif** (`77a0a8a`) : un domaine n'est retenu que si un token identifiant **est**
un segment du domaine (`durand` ↔ `garage-durand.fr`), ou si le nom concaténé **est**
un segment / la racine entière (`GARAGE DURAND` ↔ `garagedurand.fr`). Plus jamais de
sous-chaîne.

## 3. Résultat : recall 0/15 — et c'est la bonne nouvelle

| Approche | « Taux » contact | Réalité |
|---|---|---|
| Naïve (tout ce qui traîne) | 83 % | faux positifs — mauvaise société |
| + filtre domaine | 58 % | encore faux |
| + nom, par sous-chaîne | 3/15 (20 %) | **3/3 faux** — mesuré |
| **+ nom, mots entiers (retenu)** | **0/15** | **0 faux positif** |

Le passage de 3/15 à 0/15 n'est pas une régression : les 3 étaient faux.

## 4. Pourquoi 0 — le diagnostic décisif

0/15 est ambigu (filtre trop strict, ou rien à trouver ?). J'ai donc dumpé les 5
premiers résultats de recherche des 15 prospects. **Le site de la bonne entreprise
n'apparaît quasiment jamais.** Ce qui remonte à la place :

- des **annuaires d'entreprises** — `societe.com`, `pappers.fr`, `bottin.fr`,
  `leguichetdesformalites.fr`, `annuaire-entreprises.data.gouv.fr` — qui ont le SIRET
  mais ne publient ni email ni téléphone ;
- des **homonymes célèbres** — SAMIR AIT MOHAND → le gymnaste olympique Samir Aït
  Saïd ; GILBERT SERVANS → le restaurant Le Servan ; THOMAS FISCHER → une galerie
  d'art et un cadre de Novartis.

Cause structurelle, visible dans notre propre parser (`agents/sirene_agent.py:73`) :
faute de `denominationUniteLegale`, on retombe sur `prenom1UniteLegale +
nomUniteLegale`. **La plupart des petits garages parisiens sont des entreprises
individuelles enregistrées au nom civil du gérant** — et un nom de personne est
inexploitable pour retrouver un site d'entreprise.

Conséquence : **aucune vérification d'identité ne peut sauver le recall ici** (SIRET
des mentions légales, etc.) — il n'y a pas de bon site dans l'ensemble candidat à
vérifier. Le filtre n'est pas trop strict ; il rejette correctement.

Limite restante, assumée : 3 domaines ont quand même été acceptés sur les 15
(`autonova.co`, `integral-led.com`, `integral-online.com`) — toujours la mauvaise
société, par match exact sur un mot courant (« integral »). L'identification par le
nom est structurellement inadaptée à cette population, quel que soit le niveau de
strictness.

Pistes écartées après vérification : `recherche-entreprises.api.gouv.fr` ne renvoie
**aucun** champ de contact (ni `site_web`, ni `email`, ni `telephone`) ;
`enseigne1Etablissement` (nom commercial, non lu par notre parser) n'était renseigné
que pour 1 garage sur 8 échantillonnés.

## 5. Crawl4AI : gain mesuré = 0

Comparaison contrôlée LEAN (`Tavily→DDG`) vs FULL (`+Crawl4AI`), même échantillon
Sirene copié en profondeur pour chaque bras :

| métrique | LEAN | FULL | delta |
|---|---|---|---|
| avec_email | 2 | 2 | **0** |
| avec_tel | 2 | 2 | **0** |
| avec_contact | 3 | 3 | **0** |
| emails / tels bruts | 3 / 6 | 3 / 6 | **0** |

Le palier Crawl4AI **s'est bien déclenché** (3/15 ; navigateur vérifié en rendu réel
au préalable, donc ce n'est pas un faux négatif d'échec silencieux) et n'a apporté
**aucun** contact. Résultats identiques au bit près. Confirmé une 2ᵉ fois après le
durcissement du filtre.

Le goulot est l'**identification du bon site**, pas le rendu JS.

Coût d'installation sous Windows, en prime : `pip install crawl4ai` **échoue**
(`OSError`, limite `MAX_PATH` de 260 caractères sur `litellm/proxy/_experimental/…`).
Le contournement `--no-deps` ne marche qu'après un premier run échoué → **non
reproductible depuis un clone propre**. Et 65 paquets supplémentaires (44 → 109).

→ Proposition : **retirer `crawl4ai` de `requirements.txt`** en gardant
`_resolve_crawl4ai` et la liste `RESOLVERS` pluggable (le résolveur dégrade déjà
silencieusement si l'import échoue). Rien n'est perdu, le retour est une ligne.
**Non appliqué dans cette PR — décision en attente.**

## 6. Règle #3 : vocabulaire générique dérivé de l'ICP

Le garde-fou `tests/test_no_hardcoded_icp.py` (#4) échouait : le filtre s'appuyait sur
un `_GENERIC_TOKENS` codant en dur du vocabulaire du secteur auto (`garage`,
`carrosserie`, `pneus`…) dans la logique de production.

Or « quels mots n'identifient personne » **dépend de la campagne** : pour des garages
c'est « garage », pour des boulangeries « boulangerie ». Ce vocabulaire vient donc de
l'ICP client — `mots_cles_positifs` / `mots_cles_negatifs`, chargés en base par
`init_campagne` (#16) — via `generic_tokens(state["criteres"])`, complété par la ville
du prospect. Seul le boilerplate juridique (`sarl`, `sasu`, `société`…), réellement
universel, reste en dur.

Effet de bord : le contrat des résolveurs prend un 5ᵉ argument (`generic`). Le seed
pilote récupère son vocabulaire sectoriel dans `mots_cles_positifs`
(`config/icp_seed_example.py`, seul emplacement légitime), où il sert aussi de signaux
positifs au scoring #24.

## 7. Politique email #10 conservée + terrain de test

`contact@`/`info@` restent → `None` sur `Prospect.email`. Tous les contacts bruts
trouvés sont conservés dans `raw_data['enrichissement']`.

⚠️ **Mais ce dataset est contaminé** (contacts de mauvaises sociétés) : #65 ne doit
**pas** s'appuyer dessus tel quel pour argumenter le réalignement RGPD.

## Tests

**120 unitaires** (HTTP mocké) : extraction (mailto + regex + assets), dérivation du
vocabulaire depuis l'ICP, non-régression des 4 faux positifs réels, rejet du match par
sous-chaîne, politique #10, ordre de cascade, batch, parsing Tavily.

## Deps

`+ beautifulsoup4`, `+ ddgs`, `+ crawl4ai` (candidat au retrait, §5).
`+ settings.tavily_api_key`.

## Suites

- **#21 Dropcontact devient le chemin principal** pour le recall, plus une simple
  amélioration : il génère `prenom.nom@domaine` à partir d'un domaine **déjà connu**,
  ce qui contourne entièrement le problème d'identification décrit en §4.
- #65 — réalignement RGPD email (attention au §7).
- #63 — NAF 4520Z → 4520A/4520B (déjà appliqué dans les scripts de mesure).
