### PR TITLE
feat(#68): détection des adresses de domiciliation (45% des prospects, cause racine de l'échec #18)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -43,6 +43,14 @@ class Settings(BaseSettings):
     # ---------- APIs collecte ----------
     insee_api_key: str = ""  # api-sirene/3.11 (header X-INSEE-Api-Key-Integration)
 
+    # ---------- Qualité des prospects (#68) ----------
+    # Au-delà de N établissements actifs à la MÊME adresse, on considère qu'il
+    # s'agit d'une société de domiciliation (siège social / boîte aux lettres)
+    # et non d'un local d'exploitation. Calibré sur 40 garages parisiens réels :
+    # adresses ordinaires 3-134, domiciliations 778-44589 (cf. issue #68).
+    # ⚠️ Dépend de la densité urbaine — à réévaluer hors grande ville.
+    domiciliation_seuil: int = 300
+
     @property
     def postgres_dsn(self) -> str:
         return (

--- a/tests/test_domiciliation.py
+++ b/tests/test_domiciliation.py
@@ -1,0 +1,160 @@
+"""Tests de la détection d'adresses de domiciliation (#68). HTTP mocké."""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from config.settings import Settings
+from models.prospect import Prospect
+from utils import domiciliation as dom
+
+CID = uuid.uuid4()
+
+
+def _prospect(numero="47", libelle="VIVIENNE", commune="75102",
+              type_voie="RUE", nom="GARAGE TEST") -> Prospect:
+    adresse = {}
+    if numero is not None:
+        adresse["numeroVoieEtablissement"] = numero
+    if type_voie is not None:
+        adresse["typeVoieEtablissement"] = type_voie
+    if libelle is not None:
+        adresse["libelleVoieEtablissement"] = libelle
+    if commune is not None:
+        adresse["codeCommuneEtablissement"] = commune
+    return Prospect(campagne_id=CID, nom_entreprise=nom,
+                    raw_data={"adresseEtablissement": adresse})
+
+
+def _settings(seuil=300) -> Settings:
+    return Settings(insee_api_key="test-key", domiciliation_seuil=seuil)
+
+
+def _client(total, compteur=None) -> httpx.AsyncClient:
+    def handler(request):
+        if compteur is not None:
+            compteur.append(str(request.url))
+        return httpx.Response(200, json={"header": {"total": total}})
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# --- Extraction de l'adresse ------------------------------------------------
+def test_cle_adresse_depuis_champs_bruts():
+    cle = dom.cle_adresse(_prospect().raw_data)
+    assert cle == dom.AdresseCle("47", "RUE", "VIVIENNE", "75102")
+
+
+def test_cle_adresse_none_sans_numero():
+    """Sans numéro on compterait toute la rue (mesuré : 44 589 vs 42 055)."""
+    assert dom.cle_adresse(_prospect(numero=None).raw_data) is None
+
+
+def test_cle_adresse_none_si_raw_data_vide():
+    assert dom.cle_adresse(None) is None
+    assert dom.cle_adresse({}) is None
+
+
+def test_requete_enveloppe_le_champ_periode():
+    """`etatAdministratifEtablissement` est un champ période → sinon HTTP 400 (#15)."""
+    q = dom._requete(dom.AdresseCle("47", "RUE", "VIVIENNE", "75102"))
+    assert "periode(etatAdministratifEtablissement:A)" in q
+    assert 'numeroVoieEtablissement:"47"' in q
+    assert 'libelleVoieEtablissement:"VIVIENNE"' in q
+
+
+# --- Marquage ---------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_marque_adresse_de_domiciliation():
+    p = _prospect()
+    async with _client(8316) as client:
+        await dom.marquer_domiciliation([p], client, _settings())
+    assert dom.est_domicilie(p)
+    assert p.raw_data["domiciliation"]["etablissements_a_cette_adresse"] == 8316
+
+
+@pytest.mark.asyncio
+async def test_ne_marque_pas_une_adresse_ordinaire():
+    p = _prospect(numero="16", libelle="DE MAGDEBOURG", commune="75116")
+    async with _client(18) as client:
+        await dom.marquer_domiciliation([p], client, _settings())
+    assert not dom.est_domicilie(p)
+    assert p.raw_data["domiciliation"]["etablissements_a_cette_adresse"] == 18
+
+
+@pytest.mark.asyncio
+async def test_seuil_configurable():
+    """Le même comptage change de verdict selon le seuil — pas de constante magique."""
+    p_bas, p_haut = _prospect(), _prospect()
+    async with _client(200) as client:
+        await dom.marquer_domiciliation([p_bas], client, _settings(seuil=100))
+        await dom.marquer_domiciliation([p_haut], client, _settings(seuil=1000))
+    assert dom.est_domicilie(p_bas)
+    assert not dom.est_domicilie(p_haut)
+
+
+@pytest.mark.asyncio
+async def test_adresse_partagee_interrogee_une_seule_fois(monkeypatch):
+    """3 prospects à la même adresse → 1 seul appel API (quota Sirene 30/min)."""
+    monkeypatch.setattr(dom, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(nom=f"GARAGE {i}") for i in range(3)]
+    async with _client(8316, appels) as client:
+        cache = await dom.marquer_domiciliation(prospects, client, _settings())
+    assert len(appels) == 1
+    assert len(cache) == 1
+    assert all(dom.est_domicilie(p) for p in prospects)
+
+
+@pytest.mark.asyncio
+async def test_adresses_distinctes_interrogees_separement(monkeypatch):
+    monkeypatch.setattr(dom, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(numero="47"), _prospect(numero="16", libelle="DE MAGDEBOURG")]
+    async with _client(500, appels) as client:
+        await dom.marquer_domiciliation(prospects, client, _settings())
+    assert len(appels) == 2
+
+
+@pytest.mark.asyncio
+async def test_prospect_sans_numero_est_ignore(monkeypatch):
+    monkeypatch.setattr(dom, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    p = _prospect(numero=None)
+    async with _client(9999, appels) as client:
+        await dom.marquer_domiciliation([p], client, _settings())
+    assert appels == []                       # aucun appel inutile
+    assert "domiciliation" not in (p.raw_data or {})
+    assert not dom.est_domicilie(p)
+
+
+# --- Dégradation ------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_api_en_erreur_ne_casse_pas_le_run():
+    def handler(request):
+        return httpx.Response(500, text="boom")
+    p = _prospect()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await dom.marquer_domiciliation([p], client, _settings())
+    assert "domiciliation" not in (p.raw_data or {})   # rien marqué à tort
+    assert not dom.est_domicilie(p)
+
+
+@pytest.mark.asyncio
+async def test_sans_cle_api_aucun_marquage():
+    p = _prospect()
+    async with _client(8316) as client:
+        await dom.marquer_domiciliation([p], client, Settings(insee_api_key=""))
+    assert not dom.est_domicilie(p)
+
+
+@pytest.mark.asyncio
+async def test_raw_data_existant_preserve():
+    p = _prospect()
+    p.raw_data = {**p.raw_data, "enrichissement": {"emails": ["a@b.fr"]}}
+    async with _client(8316) as client:
+        await dom.marquer_domiciliation([p], client, _settings())
+    assert p.raw_data["enrichissement"] == {"emails": ["a@b.fr"]}
+    assert p.raw_data["adresseEtablissement"]["numeroVoieEtablissement"] == "47"
+    assert p.raw_data["domiciliation"]["suspecte"] is True

--- a/utils/domiciliation.py
+++ b/utils/domiciliation.py
@@ -1,0 +1,167 @@
+"""Détection des adresses de domiciliation (#68) — qualité des prospects.
+
+Beaucoup d'établissements Sirene sont enregistrés chez un **domiciliataire**
+(société qui fournit une adresse de siège social et fait suivre le courrier), pas
+dans un local d'exploitation. Mesuré sur 40 garages parisiens réels : 3 prospects
+partagent le 47 rue Vivienne, où **8 316 établissements actifs** sont enregistrés ;
+5 autres se partagent deux adresses hébergeant 42 055 et 4 219 établissements.
+
+Deux conséquences, d'où cette détection :
+
+1. **Qualité** — un « garage » domicilié dans le 2ᵉ arrondissement n'a pas
+   d'atelier : c'est un mauvais prospect pour un logiciel de gestion d'atelier.
+2. **Mesure** — c'est la cause racine de l'échec de l'enrichissement (#18/PR #66,
+   0 % d'email et de téléphone) : ces établissements n'ont aucune existence
+   physique localisable, donc ni site, ni fiche annuaire, ni point sur une carte.
+   Tant qu'on ne les écarte pas, tout taux d'enrichissement est faussé.
+
+On **marque**, on ne supprime pas : un immeuble de bureaux légitime peut héberger
+des dizaines d'entreprises, et la décision d'exclure appartient au scoring / à
+l'ICP du client. Aucune liste de domiciliataires n'est codée en dur — c'est le
+**comptage** qui décide (règle #3).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Iterable, NamedTuple
+
+import httpx
+
+from config.settings import Settings, get_settings
+from models.prospect import Prospect
+
+logger = logging.getLogger(__name__)
+
+# Même API que la collecte (#15). Constante locale : `utils/` ne dépend pas de
+# `agents/` (sens des dépendances).
+INSEE_BASE = "https://api.insee.fr/api-sirene/3.11"
+MIN_INTERVAL_S = 2.0  # Sirene : 30 req/min
+
+
+class AdresseCle(NamedTuple):
+    """Adresse normalisée, telle que Sirene la stocke."""
+    numero: str
+    type_voie: str | None
+    libelle_voie: str
+    code_commune: str
+
+
+def cle_adresse(raw_data: dict | None) -> AdresseCle | None:
+    """Extrait l'adresse exacte depuis le JSON Sirene conservé dans `raw_data`.
+
+    On repart des **champs bruts** et non de `Prospect.adresse` (chaîne
+    concaténée) : re-parser une chaîne donne des faux positifs sur les noms de
+    voie. Vérifié en direct — « 60 RUE FRANCOIS IER » (chiffre romain, tel que
+    Sirene le stocke) et « 60 rue François 1er » ne renvoient pas le même nombre.
+
+    Retourne None si l'adresse est inexploitable, notamment **sans numéro de
+    voie** : on compterait alors toute la rue (mesuré : 44 589 établissements
+    pour « RUE FRANCOIS IER » sans numéro, contre 42 055 au n° 60).
+    """
+    adresse = (raw_data or {}).get("adresseEtablissement") or {}
+    numero = adresse.get("numeroVoieEtablissement")
+    libelle = adresse.get("libelleVoieEtablissement")
+    commune = adresse.get("codeCommuneEtablissement")
+    if not (numero and libelle and commune):
+        return None
+    return AdresseCle(str(numero), adresse.get("typeVoieEtablissement"),
+                      str(libelle), str(commune))
+
+
+def _requete(cle: AdresseCle) -> str:
+    parties = [
+        f'numeroVoieEtablissement:"{cle.numero}"',
+        f'libelleVoieEtablissement:"{cle.libelle_voie}"',
+        f"codeCommuneEtablissement:{cle.code_commune}",
+    ]
+    if cle.type_voie:
+        parties.append(f'typeVoieEtablissement:"{cle.type_voie}"')
+    # Champ « période » → doit être enveloppé, sinon HTTP 400 (cf. #15).
+    parties.append("periode(etatAdministratifEtablissement:A)")
+    return " AND ".join(parties)
+
+
+async def compter_a_adresse(
+    cle: AdresseCle, client: httpx.AsyncClient, settings: Settings
+) -> int | None:
+    """Nombre d'établissements ACTIFS à cette adresse exacte. None si l'API échoue."""
+    if not settings.insee_api_key:
+        logger.warning("insee_api_key absente — détection de domiciliation ignorée")
+        return None
+    try:
+        resp = await client.get(
+            f"{INSEE_BASE}/siret",
+            params={"q": _requete(cle), "nombre": 1},
+            headers={"X-INSEE-Api-Key-Integration": settings.insee_api_key,
+                     "Accept": "application/json"},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        return resp.json().get("header", {}).get("total")
+    except Exception as exc:  # une adresse non vérifiable ne casse pas le run
+        logger.warning("comptage domiciliation KO (%s) : %s", cle.libelle_voie, exc)
+        return None
+
+
+async def marquer_domiciliation(
+    prospects: Iterable[Prospect],
+    client: httpx.AsyncClient | None = None,
+    settings: Settings | None = None,
+) -> dict[AdresseCle, int]:
+    """Marque les prospects situés à une adresse de domiciliation.
+
+    Écrit dans `raw_data['domiciliation']` : le comptage, le seuil appliqué et le
+    verdict — on garde la traçabilité plutôt que de supprimer la fiche.
+
+    Les adresses sont **dédupliquées** : plusieurs prospects partagent souvent la
+    même (c'est précisément le signal), et l'API Sirene est limitée à 30 req/min.
+    Retourne le cache {adresse: comptage} pour inspection/tests.
+    """
+    settings = settings or get_settings()
+    prospects = list(prospects)
+    cache: dict[AdresseCle, int] = {}
+
+    ferme_client = client is None
+    client = client or httpx.AsyncClient()
+    try:
+        premier = True
+        for prospect in prospects:
+            cle = cle_adresse(prospect.raw_data)
+            if cle is None:
+                continue
+            if cle not in cache:
+                if not premier:
+                    await asyncio.sleep(MIN_INTERVAL_S)
+                premier = False
+                total = await compter_a_adresse(cle, client, settings)
+                if total is None:
+                    continue
+                cache[cle] = total
+            total = cache[cle]
+            prospect.raw_data = {
+                **(prospect.raw_data or {}),
+                "domiciliation": {
+                    "etablissements_a_cette_adresse": total,
+                    "seuil": settings.domiciliation_seuil,
+                    "suspecte": total >= settings.domiciliation_seuil,
+                },
+            }
+    finally:
+        if ferme_client:
+            await client.aclose()
+
+    marques = sum(
+        1 for p in prospects
+        if (p.raw_data or {}).get("domiciliation", {}).get("suspecte")
+    )
+    logger.info(
+        "domiciliation : %d/%d prospects marqués (%d adresses distinctes vérifiées)",
+        marques, len(prospects), len(cache),
+    )
+    return cache
+
+
+def est_domicilie(prospect: Prospect) -> bool:
+    """Verdict porté par `marquer_domiciliation`. False si non vérifié."""
+    return bool((prospect.raw_data or {}).get("domiciliation", {}).get("suspecte"))


### PR DESCRIPTION
Ferme #68.

## Le constat

Beaucoup d'établissements Sirene sont enregistrés chez un **domiciliataire**
(société qui fournit une adresse de siège social et fait suivre le courrier), pas
dans un local d'exploitation.

Validation live sur 20 garages parisiens (NAF 4520A/B, dept 75) — **9/20 (45 %)** :

| prospect | établissements à cette adresse | verdict |
|---|---|---|
| AUTONOVA | 42 055 | domiciliation |
| ROBERT GUERCHOUX | 42 055 | domiciliation |
| THOMAS FISCHER | 42 055 | domiciliation |
| AMIN BELFQUIH | 8 316 | domiciliation |
| ELIO SCHROERS-SANTORO | 8 316 | domiciliation |
| AMIANI | 8 316 | domiciliation |
| SOPHIANE GOMEZ | 5 467 | domiciliation |
| SAMIR AIT MOHAND | 4 219 | domiciliation |
| C.F.F. CHARRIERE | 2 728 | domiciliation |
| BAYARD AUTOMOBILE | 8 | ok |
| SPEEDY FRANCE SAS | 7 | ok |
| INTEGRAL PARE BRISE | 18 | ok |
| … | 6 – 134 | ok |

## Ça explique #18 (PR #66)

#18 mesurait **0 % d'email et 0 % de téléphone** par recherche web. On l'avait
attribué à « les petites structures n'ont pas de site ». La vraie raison est plus
simple : **une bonne partie de ces prospects n'a aucune existence physique
localisable**.

Les faux positifs les plus frappants de #18 sont tous à une adresse de
domiciliation : AUTONOVA (→ un concessionnaire de Montréal), AMIN BELFQUIH (→ une
marque de mode), THOMAS FISCHER (→ une galerie d'art allemande), SAMIR AIT MOHAND
(→ un gymnaste olympique). La recherche ne trouvait rien de pertinent parce qu'il
n'y a rien à trouver.

**Conséquence pour la suite : tout taux d'enrichissement mesuré sans ce filtre est
faussé.** #22 (E2E) et #69 (OSM) devraient tourner après lui, sinon on mesurera à
nouveau la domiciliation en croyant mesurer la source.

## Implémentation

`utils/domiciliation.py` — comptage des établissements actifs à l'adresse **exacte**
via l'API Sirene (déjà utilisée par #15, aucune dépendance nouvelle).

Décisions notables :

- **Repart des champs bruts de `raw_data`**, pas de `Prospect.adresse`. Re-parser la
  chaîne concaténée donne de faux comptages : Sirene stocke « FRANCOIS **IER** »
  (chiffre romain) — interroger « FRANCOIS 1ER » renvoyait 347 au lieu de 42 055.
- **Adresse sans numéro de voie → ignorée.** Sinon on compte toute la rue : mesuré
  44 589 pour « RUE FRANCOIS IER » sans numéro contre 42 055 au n° 60.
- **Déduplication + throttle.** Plusieurs prospects partagent souvent l'adresse
  (c'est le signal lui-même) : 20 prospects → 16 requêtes, 2 s entre chacune
  (quota Sirene 30 req/min).
- **On marque, on ne supprime pas** (`raw_data['domiciliation']`) : un immeuble de
  bureaux légitime peut héberger des dizaines d'entreprises. La décision d'exclure
  revient au scoring / à l'ICP du client.
- **Seuil configurable** (`settings.domiciliation_seuil`, défaut **300**), jamais de
  constante magique. Calibré sur 40 garages : adresses ordinaires **3-134**,
  domiciliations **778-44 589**.
- **Aucune liste de domiciliataires en dur** — c'est le comptage qui décide
  (règle #3). Garde-fou `test_no_hardcoded_icp` vert.
- **Dégradation silencieuse** : API en erreur ou clé absente → rien n'est marqué, le
  run continue.

## Tests

13 unitaires, HTTP mocké (aucun appel réseau) : extraction d'adresse, rejet sans
numéro, enveloppe `periode(...)`, marquage au-dessus/en-dessous du seuil, seuil
configurable, **une seule requête pour une adresse partagée**, préservation du
`raw_data` existant, API en erreur, clé absente. Plus la validation live ci-dessus.

## Volontairement hors périmètre

Le branchement dans `nettoyage_agent.py` est laissé à **#19** (lane de @95902) : la
fonction est prête à appeler, et ça évite les conflits add/add rencontrés sur
#13/#14. Appel côté #19 :

```python
from utils.domiciliation import marquer_domiciliation
await marquer_domiciliation(state["prospects"])
```

## À discuter

- **Le seuil de 300 dépend de la densité urbaine.** Il est calibré sur Paris ; dans
  une petite ville, 50 entreprises à une adresse serait déjà une domiciliation. À
  réévaluer quand un ICP visera une autre zone.
- **45 % des prospects marqués, c'est énorme.** Question produit plus que technique :
  faut-il les exclure de la collecte, ou les garder avec un score dégradé ? Ça touche
  le volume annoncé au client pilote (#35).
