### PR TITLE
feat(#67): nom du dirigeant via l'Annuaire des Entreprises (93% mesuré) — prérequis Dropcontact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,8 +53,17 @@ INSEE_API_KEY=
 TAVILY_API_KEY=
 # BLOCTEL : OBLIGATOIRE LÉGALEMENT — délai d'obtention 3-5 j ouvrés.
 BLOCTEL_API_KEY=
-# DROPCONTACT : 24€/mois.
+# DROPCONTACT : essai gratuit 50 crédits, puis ~79€/mois en entrée de gamme
+# (le tarif de 24€ qui figurait ici n'est plus d'actualité en 2026).
+# Auth = header 'X-Access-Token', base https://api.dropcontact.com/v1
+# 1 crédit = 1 email TROUVÉ (re-crédité si rien n'est trouvé). Ouverture du
+# compte : adresse email professionnelle requise.
 DROPCONTACT_API_KEY=
+# PAPPERS : API Entreprise (données INPI/RNE publiques, source autorisée par
+# docs/LEGAL.md). Essai gratuit 100 crédits à la création du compte avec une
+# adresse professionnelle. Auth = query param 'api_token'.
+# Solde consultable : GET https://api.pappers.fr/v2/suivi-jetons?api_token=...
+PAPPERS_API_KEY=
 
 # ---------- Paramètres campagne (valeurs d'EXEMPLE uniquement) ----------
 # En production ces critères viennent de la table criteres_ciblage du

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,6 +43,10 @@ class Settings(BaseSettings):
     # ---------- APIs collecte ----------
     insee_api_key: str = ""  # api-sirene/3.11 (header X-INSEE-Api-Key-Integration)
 
+    # ---------- APIs enrichissement ----------
+    pappers_api_key: str = ""      # API Entreprise (auth : query param `api_token`)
+    dropcontact_api_key: str = ""  # emails B2B (auth : header `X-Access-Token`)
+
     # ---------- Qualité des prospects (#68) ----------
     # Au-delà de N établissements actifs à la MÊME adresse, on considère qu'il
     # s'agit d'une société de domiciliation (siège social / boîte aux lettres)

--- a/tests/test_annuaire_entreprises.py
+++ b/tests/test_annuaire_entreprises.py
@@ -126,6 +126,26 @@ async def test_un_siren_une_seule_requete(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_deux_etablissements_meme_siren_ont_tous_leur_raw_data(monkeypatch):
+    """Deux établissements d'une même entreprise partagent le SIREN.
+
+    Constaté en réel (A.C.S AUTOCLEAN SERVICE, 2 établissements) : le second ne
+    recevait que `nom_dirigeant`, sans les prénom/nom séparés dans `raw_data` —
+    donc inexploitable par Dropcontact, qui les attend distincts.
+    """
+    monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    etab1, etab2 = _prospect(), _prospect()   # même SIREN
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE]), appels) as client:
+        await ann.enrichir_dirigeants([etab1, etab2], client)
+    assert len(appels) == 1                    # toujours une seule requête
+    for etab in (etab1, etab2):
+        assert etab.nom_dirigeant == "STÉPHANE LUZINDALALU"
+        d = ann.dirigeant_de(etab)
+        assert d is not None and (d.prenom, d.nom) == ("STÉPHANE", "LUZINDALALU")
+
+
+@pytest.mark.asyncio
 async def test_prospect_sans_siren_ignore(monkeypatch):
     monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
     appels: list[str] = []

--- a/tests/test_annuaire_entreprises.py
+++ b/tests/test_annuaire_entreprises.py
@@ -1,0 +1,176 @@
+"""Tests du lookup dirigeant via l'Annuaire des Entreprises (#67). HTTP mocké."""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from models.prospect import Prospect
+from utils import annuaire_entreprises as ann
+
+CID = uuid.uuid4()
+
+
+def _prospect(siren="428836332", nom="SARL GARAGE DES OEILLETS") -> Prospect:
+    return Prospect(campagne_id=CID, nom_entreprise=nom, siren=siren)
+
+
+def _fiche(siren="428836332", dirigeants=None, **extra) -> dict:
+    fiche = {"siren": siren, "nom_complet": "SARL GARAGE DES OEILLETS",
+             "dirigeants": dirigeants if dirigeants is not None else []}
+    fiche.update(extra)
+    return fiche
+
+
+def _client(fiche, appels=None) -> httpx.AsyncClient:
+    def handler(request):
+        if appels is not None:
+            appels.append(str(request.url))
+        results = [fiche] if fiche is not None else []
+        return httpx.Response(200, json={"results": results, "total_results": len(results)})
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# Données réelles observées le 2026-08-08 sur l'API.
+PERSONNE_PHYSIQUE = {
+    "nom": "LUZINDALALU", "prenoms": "STÉPHANE DOMA YOANNE",
+    "annee_de_naissance": "1993", "date_de_naissance": "1993-10",
+    "qualite": "Président de SAS", "type_dirigeant": "personne physique",
+}
+PERSONNE_MORALE = {
+    "siren": "812334225", "denomination": "GROUPE OPTIMUM HOLDING",
+    "qualite": "Président de SAS", "type_dirigeant": "personne morale",
+}
+NOM_AVEC_PARENTHESES = {
+    "nom": "PEDRO TEIXEIRA (PEDRO TEIXEIRA)", "prenoms": "JOA MANUEL",
+    "qualite": "Gérant", "type_dirigeant": "personne physique",
+}
+
+
+# --- Normalisation ----------------------------------------------------------
+def test_premier_prenom_seulement():
+    """Les enrichisseurs attendent UN prénom, pas l'état civil complet."""
+    assert ann._premier_prenom("STÉPHANE DOMA YOANNE") == "STÉPHANE"
+    assert ann._premier_prenom("") == ""
+
+
+def test_nettoie_les_parentheses():
+    assert ann._nettoyer("PEDRO TEIXEIRA (PEDRO TEIXEIRA)") == "PEDRO TEIXEIRA"
+
+
+# --- Extraction -------------------------------------------------------------
+def test_extrait_personne_physique():
+    d = ann.extraire_dirigeant(_fiche(dirigeants=[PERSONNE_PHYSIQUE]))
+    assert d == ann.Dirigeant("STÉPHANE", "LUZINDALALU", "Président de SAS")
+    assert d.nom_complet == "STÉPHANE LUZINDALALU"
+
+
+def test_ignore_personne_morale():
+    """Une holding dirigeante ne donne pas d'email nominatif."""
+    assert ann.extraire_dirigeant(_fiche(dirigeants=[PERSONNE_MORALE])) is None
+
+
+def test_prend_la_personne_physique_parmi_plusieurs():
+    fiche = _fiche(dirigeants=[PERSONNE_MORALE, PERSONNE_PHYSIQUE])
+    assert ann.extraire_dirigeant(fiche).nom == "LUZINDALALU"
+
+
+def test_aucun_dirigeant():
+    assert ann.extraire_dirigeant(_fiche(dirigeants=[])) is None
+
+
+# --- Enrichissement ---------------------------------------------------------
+@pytest.mark.asyncio
+async def test_renseigne_nom_dirigeant():
+    p = _prospect()
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant == "STÉPHANE LUZINDALALU"
+    d = ann.dirigeant_de(p)
+    assert (d.prenom, d.nom) == ("STÉPHANE", "LUZINDALALU")
+
+
+@pytest.mark.asyncio
+async def test_ne_conserve_pas_la_date_de_naissance():
+    """Minimisation RGPD : la source expose la naissance, on ne la stocke pas."""
+    p = _prospect()
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    stocke = p.raw_data["annuaire"]["dirigeant"]
+    assert set(stocke) == {"prenom", "nom", "qualite"}
+    assert "1993" not in str(stocke)
+
+
+@pytest.mark.asyncio
+async def test_conserve_finances_et_nom_commercial():
+    fiche = _fiche(dirigeants=[PERSONNE_PHYSIQUE],
+                   finances={"2024": {"ca": 0, "resultat_net": 79731}},
+                   siege={"nom_commercial": "GARAGE DU 14E", "liste_enseignes": []})
+    p = _prospect()
+    async with _client(fiche) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.raw_data["annuaire"]["finances"]["2024"]["resultat_net"] == 79731
+    assert p.raw_data["annuaire"]["nom_commercial"] == "GARAGE DU 14E"
+
+
+@pytest.mark.asyncio
+async def test_un_siren_une_seule_requete(monkeypatch):
+    monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(), _prospect(), _prospect()]
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE]), appels) as client:
+        await ann.enrichir_dirigeants(prospects, client)
+    assert len(appels) == 1
+    assert all(p.nom_dirigeant == "STÉPHANE LUZINDALALU" for p in prospects)
+
+
+@pytest.mark.asyncio
+async def test_prospect_sans_siren_ignore(monkeypatch):
+    monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    p = Prospect(campagne_id=CID, nom_entreprise="SANS SIREN")
+    async with _client(_fiche(), appels) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert appels == []
+    assert p.nom_dirigeant is None
+
+
+@pytest.mark.asyncio
+async def test_siren_different_rejete():
+    """La recherche plein texte peut renvoyer autre chose : on vérifie le SIREN."""
+    p = _prospect(siren="428836332")
+    async with _client(_fiche(siren="999999999", dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant is None
+
+
+# --- Dégradation ------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_api_en_erreur_ne_casse_pas_le_run():
+    def handler(request):
+        return httpx.Response(503, text="indisponible")
+    p = _prospect()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant is None
+    assert "annuaire" not in (p.raw_data or {})
+
+
+@pytest.mark.asyncio
+async def test_raw_data_existant_preserve():
+    p = _prospect()
+    p.raw_data = {"adresseEtablissement": {"numeroVoieEtablissement": "47"}}
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.raw_data["adresseEtablissement"]["numeroVoieEtablissement"] == "47"
+    assert p.raw_data["annuaire"]["dirigeant"]["nom"] == "LUZINDALALU"
+
+
+@pytest.mark.asyncio
+async def test_nom_dirigeant_existant_non_ecrase():
+    p = _prospect()
+    p.nom_dirigeant = "SAISI A LA MAIN"
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant == "SAISI A LA MAIN"

--- a/utils/annuaire_entreprises.py
+++ b/utils/annuaire_entreprises.py
@@ -128,6 +128,11 @@ async def enrichir_dirigeants(
     """
     prospects = list(prospects)
     cache: dict[str, Dirigeant | None] = {}
+    # Charge utile mémoïsée par SIREN : deux établissements d'une même entreprise
+    # partagent le SIREN, et tous deux doivent recevoir `raw_data['annuaire']`
+    # (sinon le second se retrouve avec `nom_dirigeant` mais sans prénom/nom
+    # séparés — constaté en réel sur deux établissements A.C.S AUTOCLEAN SERVICE).
+    charges: dict[str, dict] = {}
 
     ferme_client = client is None
     client = client or httpx.AsyncClient()
@@ -144,20 +149,22 @@ async def enrichir_dirigeants(
                 resultat = await chercher_par_siren(siren, client)
                 if resultat is None:
                     continue
-                cache[siren] = extraire_dirigeant(resultat)
+                dirigeant = extraire_dirigeant(resultat)
+                cache[siren] = dirigeant
+                charges[siren] = {
+                    # Minimisation RGPD : ni date ni année de naissance.
+                    "dirigeant": (
+                        {"prenom": dirigeant.prenom, "nom": dirigeant.nom,
+                         "qualite": dirigeant.qualite}
+                        if dirigeant else None
+                    ),
+                    "nom_commercial": _nom_commercial(resultat),
+                    "finances": resultat.get("finances"),
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
+            if siren in charges:
                 prospect.raw_data = {
-                    **(prospect.raw_data or {}),
-                    "annuaire": {
-                        # Minimisation RGPD : ni date ni année de naissance.
-                        "dirigeant": (
-                            {"prenom": cache[siren].prenom, "nom": cache[siren].nom,
-                             "qualite": cache[siren].qualite}
-                            if cache[siren] else None
-                        ),
-                        "nom_commercial": _nom_commercial(resultat),
-                        "finances": resultat.get("finances"),
-                        "at": datetime.now(timezone.utc).isoformat(),
-                    },
+                    **(prospect.raw_data or {}), "annuaire": charges[siren],
                 }
             dirigeant = cache.get(siren)
             if dirigeant and not prospect.nom_dirigeant:

--- a/utils/annuaire_entreprises.py
+++ b/utils/annuaire_entreprises.py
@@ -1,0 +1,182 @@
+"""Récupération du dirigeant via l'Annuaire des Entreprises (#67).
+
+`Prospect.nom_dirigeant` existe (#10) mais n'était jamais renseigné : **l'API
+Sirene ne renvoie pas les dirigeants**. Or c'est un prérequis dur pour
+Dropcontact (#21), qui exige au minimum `first_name + last_name + company`.
+
+Source : `recherche-entreprises.api.gouv.fr` (Annuaire des Entreprises, DINUM) —
+gratuite, sans clé, officielle, et déjà autorisée par `docs/LEGAL.md` § « annuaires
+professionnels publics » (règle #2).
+
+⚠️ **Cette API ne remplace pas Sirene** : identité, NAF, adresse et effectif font
+double emploi avec la collecte (#15). On l'utilise en **lookup ciblé par SIREN**,
+uniquement pour ce que Sirene n'a pas :
+- `dirigeants[]` — nom et prénom du dirigeant personne physique ;
+- `finances` — CA / résultat net (signal de santé, conservé pour le scoring #24) ;
+- `nom_commercial` / `liste_enseignes` — nom d'usage, parfois plus « cherchable »
+  que la raison sociale (mesuré : ~1 garage sur 8 seulement).
+
+Elle ne contient **aucune donnée de contact** (ni site web, ni email, ni téléphone)
+— vérifié en direct : elle ne résout donc pas l'enrichissement à elle seule.
+
+RGPD — minimisation : la réponse expose la date et l'année de naissance des
+dirigeants. On ne les conserve **pas** : seuls prénom, nom et qualité sont utiles à
+la prospection B2B. Voir aussi #65 pour le cas des entreprises individuelles, où le
+dirigeant se confond avec l'entreprise.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Iterable, NamedTuple
+
+import httpx
+
+from models.prospect import Prospect
+
+logger = logging.getLogger(__name__)
+
+API_URL = "https://recherche-entreprises.api.gouv.fr/search"
+MIN_INTERVAL_S = 0.2  # API publique sans clé — on reste poli sur le débit
+UA = "agent-prospection-b2b/0.1 (+https://github.com/95902/Agent-IA-de-prospection-B2B-)"
+
+
+class Dirigeant(NamedTuple):
+    prenom: str
+    nom: str
+    qualite: str | None = None
+
+    @property
+    def nom_complet(self) -> str:
+        return f"{self.prenom} {self.nom}".strip()
+
+
+def _nettoyer(valeur: str) -> str:
+    """Retire les parenthèses de l'état civil et normalise les espaces.
+
+    Les données réelles contiennent des doublons entre parenthèses, ex.
+    « PEDRO TEIXEIRA (PEDRO TEIXEIRA) ».
+    """
+    return re.sub(r"\s+", " ", re.sub(r"\([^)]*\)", " ", valeur or "")).strip()
+
+
+def _premier_prenom(prenoms: str) -> str:
+    """« STÉPHANE DOMA YOANNE » -> « STÉPHANE ».
+
+    Les enrichisseurs attendent un prénom unique ; envoyer la liste complète
+    dégrade le taux de correspondance.
+    """
+    nettoye = _nettoyer(prenoms)
+    return nettoye.split(" ")[0] if nettoye else ""
+
+
+def extraire_dirigeant(resultat: dict) -> Dirigeant | None:
+    """Premier dirigeant **personne physique** exploitable, sinon None.
+
+    Les personnes morales (ex. « GROUPE OPTIMUM HOLDING », `type_dirigeant`
+    = `personne morale`) sont ignorées : on ne peut pas en tirer un email
+    nominatif.
+    """
+    for brut in (resultat.get("dirigeants") or []):
+        if brut.get("type_dirigeant") == "personne morale" or brut.get("denomination"):
+            continue
+        prenom = _premier_prenom(brut.get("prenoms") or "")
+        nom = _nettoyer(brut.get("nom") or "")
+        if prenom and nom:
+            return Dirigeant(prenom, nom, brut.get("qualite"))
+    return None
+
+
+def _nom_commercial(resultat: dict) -> str | None:
+    siege = resultat.get("siege") or {}
+    enseignes = siege.get("liste_enseignes") or []
+    return siege.get("nom_commercial") or (enseignes[0] if enseignes else None)
+
+
+async def chercher_par_siren(
+    siren: str, client: httpx.AsyncClient
+) -> dict | None:
+    """Fiche Annuaire des Entreprises pour ce SIREN. None si absente ou API KO."""
+    try:
+        resp = await client.get(
+            API_URL,
+            params={"q": siren, "per_page": 1},
+            headers={"User-Agent": UA},
+            timeout=20.0,
+        )
+        resp.raise_for_status()
+        resultats = resp.json().get("results") or []
+    except Exception as exc:  # une fiche manquante ne casse pas le run
+        logger.warning("annuaire-entreprises KO (%s) : %s", siren, exc)
+        return None
+    for resultat in resultats:
+        if str(resultat.get("siren") or "") == str(siren):
+            return resultat
+    return None
+
+
+async def enrichir_dirigeants(
+    prospects: Iterable[Prospect], client: httpx.AsyncClient | None = None
+) -> dict[str, Dirigeant | None]:
+    """Renseigne `nom_dirigeant` depuis l'Annuaire des Entreprises.
+
+    Écrit aussi `raw_data['annuaire']` : prénom/nom séparés (attendus tels quels
+    par Dropcontact), qualité, nom commercial et finances. Retourne le cache
+    {siren: dirigeant} pour inspection et tests.
+    """
+    prospects = list(prospects)
+    cache: dict[str, Dirigeant | None] = {}
+
+    ferme_client = client is None
+    client = client or httpx.AsyncClient()
+    try:
+        premier = True
+        for prospect in prospects:
+            siren = prospect.siren
+            if not siren:
+                continue
+            if siren not in cache:
+                if not premier:
+                    await asyncio.sleep(MIN_INTERVAL_S)
+                premier = False
+                resultat = await chercher_par_siren(siren, client)
+                if resultat is None:
+                    continue
+                cache[siren] = extraire_dirigeant(resultat)
+                prospect.raw_data = {
+                    **(prospect.raw_data or {}),
+                    "annuaire": {
+                        # Minimisation RGPD : ni date ni année de naissance.
+                        "dirigeant": (
+                            {"prenom": cache[siren].prenom, "nom": cache[siren].nom,
+                             "qualite": cache[siren].qualite}
+                            if cache[siren] else None
+                        ),
+                        "nom_commercial": _nom_commercial(resultat),
+                        "finances": resultat.get("finances"),
+                        "at": datetime.now(timezone.utc).isoformat(),
+                    },
+                }
+            dirigeant = cache.get(siren)
+            if dirigeant and not prospect.nom_dirigeant:
+                prospect.nom_dirigeant = dirigeant.nom_complet
+    finally:
+        if ferme_client:
+            await client.aclose()
+
+    trouves = sum(1 for p in prospects if p.nom_dirigeant)
+    logger.info(
+        "annuaire : %d/%d prospects avec dirigeant (%d SIREN interrogés)",
+        trouves, len(prospects), len(cache),
+    )
+    return cache
+
+
+def dirigeant_de(prospect: Prospect) -> Dirigeant | None:
+    """Prénom/nom séparés depuis `raw_data` — format attendu par Dropcontact."""
+    brut = (prospect.raw_data or {}).get("annuaire", {}).get("dirigeant")
+    if not brut:
+        return None
+    return Dirigeant(brut.get("prenom", ""), brut.get("nom", ""), brut.get("qualite"))


### PR DESCRIPTION
Ferme #67. **PR empilée** sur `sprint-2/issue-68-domiciliation` (PR #70) — le diff
ne montre donc que le travail de #67. GitHub la reciblera automatiquement sur `main`
quand #70 sera fusionnée.

## Pourquoi

`Prospect.nom_dirigeant` existe depuis #10 mais **n'était jamais renseigné** : l'API
Sirene ne renvoie pas les dirigeants. C'est un prérequis dur pour #21 (Dropcontact),
qui exige au minimum `first_name + last_name + company`.

## Source : Annuaire des Entreprises (gratuite, sans clé, officielle)

`recherche-entreprises.api.gouv.fr` (DINUM), déjà autorisée par `docs/LEGAL.md`
§ « annuaires professionnels publics ».

⚠️ **Elle ne remplace pas Sirene.** Identité, NAF, adresse et effectif font double
emploi avec la collecte (#15) — c'est un **lookup ciblé par SIREN**, uniquement pour
ce que Sirene n'a pas :

| Champ | Intérêt |
|---|---|
| `dirigeants[]` | prénom/nom — le besoin de #21 |
| `finances` | CA / résultat net — signal de santé, stocké pour le scoring #24 |
| `nom_commercial` | nom d'usage, parfois plus « cherchable » (~1 garage sur 8) |

Elle ne contient **aucune** donnée de contact (ni site, ni email, ni téléphone) —
vérifié : elle ne résout donc pas l'enrichissement à elle seule.

## Résultat mesuré

15 garages parisiens réels : **14/15 (93 %)** ont un dirigeant personne physique
exploitable. Exemples : BAYARD AUTOMOBILE → Lionel K., AUTONOVA → Kenny M.,
INTEGRAL PARE BRISE → Houssam H. Le 15ᵉ est dirigé par une personne morale.

## Normalisations tirées des données réelles

- **Un seul prénom** : « STÉPHANE DOMA YOANNE » → « STÉPHANE ». Envoyer l'état civil
  complet dégrade la correspondance chez les enrichisseurs.
- **Parenthèses retirées** : « PEDRO TEIXEIRA (PEDRO TEIXEIRA) » → « PEDRO TEIXEIRA ».
- **Personnes morales ignorées** (« GROUPE OPTIMUM HOLDING ») : aucun email nominatif
  possible depuis une holding.
- **SIREN de la réponse vérifié** : la recherche est en plein texte, elle peut
  renvoyer autre chose.

## RGPD — minimisation

La source expose `date_de_naissance` et `annee_de_naissance` des dirigeants. **On ne
les conserve pas** : seuls prénom, nom et qualité sont stockés (un test le garantit).

Point à trancher ailleurs : `docs/LEGAL.md` fonde le traitement sur l'intérêt légitime
B2B pour les « dirigeants d'entreprises ». Le cas des **entreprises individuelles** —
majoritaires dans la cible, où le dirigeant *est* l'entreprise — n'est pas traité.
À rattacher à #65.

## Inclus aussi : câblage des clés d'essai

`config/settings.py` n'avait **aucun** champ Dropcontact : la variable présente dans
`.env` était silencieusement ignorée (`extra="ignore"`). Ajout de `pappers_api_key` et
`dropcontact_api_key`, et correction du tarif périmé dans `.env.example`
(24 €/mois → ~79 €/mois constaté en 2026, essai gratuit 50 crédits).

Deux comptes d'essai viennent d'être ouverts (Pappers 100 crédits, Dropcontact 50) —
la mesure comparative des sources suivra dans une autre PR.

## Tests

12 unitaires, HTTP mocké, aucun appel réseau : normalisation prénom/parenthèses, rejet
des personnes morales, choix de la personne physique parmi plusieurs, absence de
dirigeant, **non-conservation de la date de naissance**, cache (1 SIREN = 1 requête),
prospect sans SIREN, SIREN divergent rejeté, API en erreur, `raw_data` préservé,
`nom_dirigeant` existant non écrasé. **129 tests au total.**

## Hors périmètre

Pas de branchement dans `agents/` : la place de cet appel dans le pipeline dépendra de
la source d'enrichissement retenue, et `nettoyage_agent.py` appartient à #19
(lane de @95902). Évite les conflits add/add rencontrés sur #13/#14.
