### PR TITLE
feat(#74): filtre d'opposition à l'utilisation commerciale — fermé par défaut ⚠️ LÉGAL

### DIFF
--- a/tests/test_opposition_commerciale.py
+++ b/tests/test_opposition_commerciale.py
@@ -1,0 +1,197 @@
+"""Tests du filtre d'opposition à l'utilisation commerciale (#74). HTTP mocké.
+
+L'enjeu de ces tests n'est pas seulement « le champ est bien lu » : c'est que le
+module soit **fermé par défaut**. Un prospect non vérifié ne doit jamais devenir
+contactable, quelle que soit la panne (API KO, clé absente, budget épuisé).
+"""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from config.settings import Settings
+from models.prospect import Prospect
+from utils import opposition_commerciale as oc
+
+CID = uuid.uuid4()
+
+# SIREN réels issus de nos mesures (août 2026). Le modèle Prospect (#10) valide
+# le checksum Luhn : des numéros inventés seraient rejetés à la construction.
+SIRENS = [
+    "322521774",  # BAYARD AUTOMOBILE   — opposée en réel
+    "107159691",  # INTEGRAL PARE BRISE — opposée en réel
+    "331816140",  # DM MOTORS           — non opposée
+    "340505346",  # HUGUES MIHEL        — non opposée
+    "313215444",  # GILBERT SERVANS     — non opposée
+]
+
+
+def _prospect(siren=SIRENS[0], nom="BAYARD AUTOMOBILE") -> Prospect:
+    return Prospect(campagne_id=CID, nom_entreprise=nom, siren=siren)
+
+
+def _settings(cle="test-key") -> Settings:
+    return Settings(pappers_api_key=cle)
+
+
+def _client(oppose, appels=None) -> httpx.AsyncClient:
+    """`oppose` : True / False / None (champ absent de la réponse)."""
+    def handler(request):
+        if appels is not None:
+            appels.append(str(request.url))
+        corps = {"siren": "322521774"}
+        if oppose is not None:
+            corps["opposition_utilisation_commerciale"] = oppose
+        return httpx.Response(200, json=corps)
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# --- Lecture du champ --------------------------------------------------------
+@pytest.mark.asyncio
+async def test_entreprise_opposee():
+    p = _prospect()
+    async with _client(True) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert oc.est_oppose(p) is True
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_entreprise_non_opposee():
+    p = _prospect()
+    async with _client(False) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert oc.est_oppose(p) is False
+    assert oc.peut_etre_contacte(p) is True
+
+
+@pytest.mark.asyncio
+async def test_tracabilite_conservee():
+    """Une exclusion doit pouvoir être justifiée : valeur, date, source, base légale."""
+    p = _prospect()
+    async with _client(True) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    bloc = p.raw_data["opposition_commerciale"]
+    assert bloc["oppose"] is True
+    assert bloc["source"] == "pappers/entreprise"
+    assert "R123-232" in bloc["base_legale"]
+    assert bloc["verifie_le"]
+
+
+# --- Fermé par défaut : le coeur du module -----------------------------------
+@pytest.mark.asyncio
+async def test_api_en_erreur_rend_le_prospect_non_contactable():
+    def handler(request):
+        return httpx.Response(500, text="boom")
+    p = _prospect()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert oc.est_oppose(p) is False          # on n'a pas prouvé l'opposition
+    assert oc.peut_etre_contacte(p) is False  # …mais on ne contacte pas pour autant
+
+
+@pytest.mark.asyncio
+async def test_cle_absente_rend_le_prospect_non_contactable():
+    p = _prospect()
+    async with _client(False) as client:
+        await oc.marquer_opposition([p], client, _settings(cle=""))
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_champ_absent_de_la_reponse_ne_conclut_pas():
+    """Pappers pourrait ne pas renvoyer le champ : ce n'est pas une autorisation."""
+    p = _prospect()
+    async with _client(None) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert p.raw_data["opposition_commerciale"]["oppose"] is None
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_prospect_jamais_verifie_non_contactable():
+    """Sans passage par le filtre, aucun prospect n'est contactable."""
+    assert oc.peut_etre_contacte(_prospect()) is False
+    assert oc.est_oppose(_prospect()) is False
+
+
+def test_negation_de_est_oppose_nest_pas_une_autorisation():
+    """Garde-fou explicite contre le contresens `not est_oppose(p)`."""
+    p = _prospect()  # jamais vérifié
+    assert not oc.est_oppose(p)            # tentant…
+    assert not oc.peut_etre_contacte(p)    # …mais c'est bien celui-ci qui décide
+
+
+# --- Budget de crédits -------------------------------------------------------
+@pytest.mark.asyncio
+async def test_budget_epuise_sarrete_sans_rien_autoriser(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(siren=s) for s in SIRENS]
+    async with _client(False, appels) as client:
+        await oc.marquer_opposition(prospects, client, _settings(), budget_credits=2)
+    assert len(appels) == 2                                   # budget respecté
+    assert sum(oc.peut_etre_contacte(p) for p in prospects) == 2
+    # les 3 restants ne sont ni vérifiés ni contactables
+    assert all(not oc.peut_etre_contacte(p) for p in prospects[2:])
+
+
+@pytest.mark.asyncio
+async def test_budget_strict_leve_une_exception(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    prospects = [_prospect(siren=s) for s in SIRENS[:3]]
+    async with _client(False) as client:
+        with pytest.raises(oc.BudgetCreditsEpuise):
+            await oc.marquer_opposition(prospects, client, _settings(),
+                                        budget_credits=1, strict=True)
+
+
+# --- Cache et volumétrie -----------------------------------------------------
+@pytest.mark.asyncio
+async def test_un_siren_une_seule_requete(monkeypatch):
+    """Plusieurs établissements partagent le SIREN : 1 crédit, pas 3."""
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(), _prospect(), _prospect()]
+    async with _client(True, appels) as client:
+        cache = await oc.marquer_opposition(prospects, client, _settings())
+    assert len(appels) == 1
+    assert len(cache) == 1
+    assert all(oc.est_oppose(p) for p in prospects)
+
+
+@pytest.mark.asyncio
+async def test_prospect_sans_siren_ignore(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    p = Prospect(campagne_id=CID, nom_entreprise="SANS SIREN")
+    async with _client(False, appels) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert appels == []
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_filtrer_contactables(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    autorise, refuse = _prospect(siren=SIRENS[2]), _prospect(siren=SIRENS[0])
+
+    def handler(request):
+        oppose = "322521774" in str(request.url)
+        return httpx.Response(200, json={"opposition_utilisation_commerciale": oppose})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await oc.marquer_opposition([autorise, refuse], client, _settings())
+    assert oc.filtrer_contactables([autorise, refuse]) == [autorise]
+
+
+@pytest.mark.asyncio
+async def test_raw_data_existant_preserve():
+    p = _prospect()
+    p.raw_data = {"domiciliation": {"etablissements_a_cette_adresse": 8}}
+    async with _client(False) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert p.raw_data["domiciliation"]["etablissements_a_cette_adresse"] == 8
+    assert p.raw_data["opposition_commerciale"]["oppose"] is False

--- a/utils/opposition_commerciale.py
+++ b/utils/opposition_commerciale.py
@@ -1,0 +1,201 @@
+"""Opposition à l'utilisation commerciale des données (#74) — filtre LÉGAL.
+
+Une entreprise peut **s'opposer formellement à l'utilisation commerciale de ses
+données** (art. R123-232 du code de commerce), choix exprimé au Guichet Unique lors
+de l'immatriculation ou via le RNE. C'est un opt-out enregistré, pas une zone
+grise : démarcher ces entreprises est précisément ce que ce droit interdit.
+
+Mesuré sur 35 entreprises réelles (Paris, août 2026) : **17 opposées, soit 49 %**.
+Et le taux grimpe à **87 % pour les SIREN récents** (immatriculés via le Guichet
+Unique depuis 2023) contre 20 % pour les anciens — il augmentera donc mécaniquement
+à mesure que le stock d'entreprises se renouvelle.
+
+Source : **aucune source gratuite n'expose ce champ.** Vérifié : `statut_diffusion`
+(Sirene et annuaire-entreprises) vaut `O` pour les opposées comme pour les autres —
+ce n'est pas le même concept. Seul Pappers le renvoie, sur `/entreprise`, **par
+défaut** : coût = l'appel de base, soit **1 crédit par entreprise**.
+
+## Le principe : fermé par défaut
+
+Ne pas savoir n'est pas une autorisation. Si l'API est indisponible, si la clé
+manque ou si le budget de crédits est épuisé, le prospect reste **non vérifié** —
+et un prospect non vérifié n'est **pas** contactable. D'où deux fonctions
+distinctes, volontairement dissymétriques :
+
+    est_oppose(p)         -> True seulement si on a VÉRIFIÉ qu'il est opposé
+    peut_etre_contacte(p) -> True seulement si on a VÉRIFIÉ qu'il ne l'est pas
+
+Utiliser `peut_etre_contacte()` comme garde avant tout envoi vers un enrichisseur
+tiers ou toute file de contact. `not est_oppose()` n'est PAS équivalent : cette
+expression laisserait passer les prospects non vérifiés.
+
+Traçabilité : la valeur et la date de vérification sont conservées dans
+`raw_data['opposition_commerciale']`, pour pouvoir justifier une exclusion — ou une
+non-exclusion — en cas de contrôle.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Iterable
+
+import httpx
+
+from config.settings import Settings, get_settings
+from models.prospect import Prospect
+
+logger = logging.getLogger(__name__)
+
+PAPPERS_BASE = "https://api.pappers.fr/v2"
+MIN_INTERVAL_S = 0.3     # API payante, mais restons polis
+COUT_CREDITS_PAR_SIREN = 1
+
+
+class BudgetCreditsEpuise(RuntimeError):
+    """Levée uniquement si `strict=True` — sinon on s'arrête proprement."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def solde_credits(client: httpx.AsyncClient, settings: Settings) -> int | None:
+    """Crédits Pappers restants. None si indisponible."""
+    try:
+        resp = await client.get(
+            f"{PAPPERS_BASE}/suivi-jetons",
+            params={"api_token": settings.pappers_api_key},
+            timeout=20.0,
+        )
+        resp.raise_for_status()
+        return resp.json().get("jetons_pay_as_you_go_restants")
+    except Exception as exc:
+        logger.warning("solde Pappers indisponible : %s", exc)
+        return None
+
+
+async def verifier_opposition(
+    siren: str, client: httpx.AsyncClient, settings: Settings
+) -> bool | None:
+    """`True` = opposée, `False` = non opposée, `None` = **non vérifiable**.
+
+    Le `None` est significatif : il ne veut pas dire « autorisée », il veut dire
+    qu'on ne sait pas — et dans ce cas on ne contacte pas.
+    """
+    if not settings.pappers_api_key:
+        logger.warning("pappers_api_key absente — opposition non vérifiable")
+        return None
+    try:
+        resp = await client.get(
+            f"{PAPPERS_BASE}/entreprise",
+            params={"api_token": settings.pappers_api_key, "siren": siren},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        valeur = resp.json().get("opposition_utilisation_commerciale")
+    except Exception as exc:
+        logger.warning("opposition non vérifiable (%s) : %s", siren, exc)
+        return None
+    # Champ absent de la réponse -> on ne conclut pas.
+    return bool(valeur) if valeur is not None else None
+
+
+async def marquer_opposition(
+    prospects: Iterable[Prospect],
+    client: httpx.AsyncClient | None = None,
+    settings: Settings | None = None,
+    budget_credits: int | None = None,
+    strict: bool = False,
+) -> dict[str, bool | None]:
+    """Vérifie l'opposition commerciale de chaque prospect et l'inscrit dans
+    `raw_data['opposition_commerciale']`.
+
+    `budget_credits` borne le nombre de SIREN interrogés (1 crédit chacun). Une
+    fois le budget atteint, on **s'arrête** : les prospects restants ne sont pas
+    vérifiés, donc pas contactables — jamais l'inverse. Sans budget explicite, tous
+    les SIREN distincts sont interrogés, ce qui peut coûter cher sur une grosse
+    campagne : à câbler avec le suivi de coûts (#23).
+
+    `strict=True` lève `BudgetCreditsEpuise` au lieu de s'arrêter silencieusement.
+
+    Retourne le cache {siren: opposé} pour inspection et tests.
+    """
+    settings = settings or get_settings()
+    prospects = list(prospects)
+    cache: dict[str, bool | None] = {}
+    interroges = 0
+
+    ferme_client = client is None
+    client = client or httpx.AsyncClient()
+    try:
+        for prospect in prospects:
+            siren = prospect.siren
+            if not siren:
+                continue
+            if siren not in cache:
+                if budget_credits is not None and interroges >= budget_credits:
+                    message = (
+                        f"budget de {budget_credits} crédit(s) atteint — "
+                        f"{len(prospects) - len(cache)} prospect(s) non vérifiés, "
+                        "donc non contactables"
+                    )
+                    if strict:
+                        raise BudgetCreditsEpuise(message)
+                    logger.warning(message)
+                    break
+                if interroges:
+                    await asyncio.sleep(MIN_INTERVAL_S)
+                cache[siren] = await verifier_opposition(siren, client, settings)
+                interroges += 1
+            prospect.raw_data = {
+                **(prospect.raw_data or {}),
+                "opposition_commerciale": {
+                    "oppose": cache[siren],
+                    "verifie_le": _now(),
+                    "source": "pappers/entreprise",
+                    "base_legale": "art. R123-232 code de commerce",
+                },
+            }
+    finally:
+        if ferme_client:
+            await client.aclose()
+
+    opposes = sum(1 for v in cache.values() if v is True)
+    inconnus = sum(1 for v in cache.values() if v is None)
+    contactables = sum(1 for p in prospects if peut_etre_contacte(p))
+    logger.info(
+        "opposition commerciale : %d opposé(s), %d non vérifiable(s), "
+        "%d/%d prospect(s) contactables — %d crédit(s) consommés",
+        opposes, inconnus, contactables, len(prospects),
+        interroges * COUT_CREDITS_PAR_SIREN,
+    )
+    return cache
+
+
+def _verdict(prospect: Prospect) -> bool | None:
+    bloc = (prospect.raw_data or {}).get("opposition_commerciale")
+    return bloc.get("oppose") if isinstance(bloc, dict) else None
+
+
+def est_oppose(prospect: Prospect) -> bool:
+    """True **seulement** si la vérification a conclu à une opposition.
+
+    ⚠️ Ne pas utiliser `not est_oppose(p)` comme autorisation de contact : un
+    prospect non vérifié renverrait False ici. Utiliser `peut_etre_contacte()`.
+    """
+    return _verdict(prospect) is True
+
+
+def peut_etre_contacte(prospect: Prospect) -> bool:
+    """True **seulement** si on a vérifié que le prospect n'est pas opposé.
+
+    C'est la garde à utiliser avant tout envoi vers un enrichisseur tiers ou toute
+    file de contact. Non vérifié -> False (fermé par défaut).
+    """
+    return _verdict(prospect) is False
+
+
+def filtrer_contactables(prospects: Iterable[Prospect]) -> list[Prospect]:
+    """Ne garde que les prospects dont la non-opposition est **vérifiée**."""
+    return [p for p in prospects if peut_etre_contacte(p)]


### PR DESCRIPTION
Ferme #74. **PR empilée** sur `sprint-2/issue-67-dirigeants` (PR #73) — le diff ne
montre donc que le travail de #74. GitHub la reciblera automatiquement au fil des
fusions. La chaîne est : #68 (domiciliation) → #67 (dirigeants) → **#74 (opposition)**.

## Pourquoi

Une entreprise peut **s'opposer formellement à l'utilisation commerciale de ses
données** (art. R123-232 du code de commerce), choix exprimé au Guichet Unique lors de
l'immatriculation. C'est un opt-out enregistré : démarcher ces entreprises est
exactement ce que ce droit interdit.

Mesuré sur 35 entreprises réelles (Paris, août 2026) :

| Population | Opposées |
|---|---|
| garages | 4/15 — 27 % |
| hôtels | 7/12 — 58 % |
| informatique | 6/8 — 75 % |
| **total** | **17/35 — 49 %** |

| Ancienneté du SIREN | Opposées |
|---|---|
| récents `1xx` (Guichet Unique, depuis 2023) | **13/15 — 87 %** |
| anciens `3xx`/`4xx` | 4/20 — 20 % |

Le taux augmentera mécaniquement à mesure que le stock d'entreprises se renouvelle.

**Rien ne testait ce champ jusqu'ici.** Le premier lot envoyé à Dropcontact pendant les
tests contenait 3 entreprises opposées — leurs dirigeants allaient partir chez un
service tiers. Écarté in extremis grâce à un `--dry-run`.

## Le point central : fermé par défaut

**Ne pas savoir n'est pas une autorisation.** API indisponible, clé manquante, budget
de crédits épuisé, champ absent de la réponse → le prospect reste *non vérifié*, et un
prospect non vérifié n'est **pas** contactable.

D'où deux fonctions volontairement dissymétriques :

```python
est_oppose(p)          # True seulement si on a VÉRIFIÉ l'opposition
peut_etre_contacte(p)  # True seulement si on a VÉRIFIÉ l'absence d'opposition
```

⚠️ **`not est_oppose(p)` n'est pas une autorisation** : un prospect jamais vérifié y
répondrait `True`. C'est le piège naturel du module, donc un test dédié le verrouille
(`test_negation_de_est_oppose_nest_pas_une_autorisation`). Utiliser
`peut_etre_contacte()` — ou `filtrer_contactables()` — comme garde avant tout envoi
vers un enrichisseur tiers ou toute file de contact.

## Garde-fou de budget

Chaque SIREN coûte **1 crédit Pappers**. Une campagne de 500 prospects coûterait donc
500 crédits — il faut pouvoir le borner :

```python
await marquer_opposition(prospects, budget_credits=100)
```

Budget atteint → on s'arrête proprement ; les prospects restants ne sont pas vérifiés,
donc **pas contactables**. Jamais l'inverse. `strict=True` lève `BudgetCreditsEpuise`
plutôt que de s'arrêter silencieusement, pour les contextes où passer sous le budget
doit être une erreur franche.

## Traçabilité

`raw_data['opposition_commerciale']` conserve la valeur, la date de vérification, la
source et la base légale — de quoi justifier une exclusion (ou une non-exclusion) en
cas de contrôle.

## Source : pourquoi Pappers et pas une source gratuite

**Aucune source gratuite n'expose ce champ.** Vérifié : `statut_diffusion` (Sirene et
annuaire-entreprises) vaut `O` pour les opposées comme pour les autres — ce n'est pas
le même concept. Seul Pappers le renvoie, sur `/entreprise`, **par défaut** : coût =
l'appel de base, 1 crédit, sans `champs_supplementaires` à demander.

C'est aujourd'hui la principale justification d'un budget Pappers — bien plus que
l'enrichissement email, mesuré à 7-17 % et largement inexploitable.

## Tests

**14 unitaires**, HTTP mocké, aucun appel réseau. La moitié porte sur le
comportement en panne, parce que c'est là que le risque est :

- API en erreur → non contactable
- clé absente → non contactable
- champ absent de la réponse → non contactable
- prospect jamais vérifié → non contactable
- `not est_oppose()` ≠ autorisation
- budget épuisé → arrêt, et rien d'autorisé au passage
- 1 SIREN partagé par 3 établissements = 1 seul crédit
- traçabilité complète, `raw_data` existant préservé

**Validation live** sur 4 entreprises dont la réponse réelle était connue
(2 opposées, 2 non opposées) : **4/4 conformes**, 1 crédit chacune, solde 15 → 11.

## Reste à faire (hors périmètre de cette PR)

- **Brancher dans `nettoyage_agent.py`** — c'est la lane de @95902 (#19). La fonction
  est prête à appeler, à placer **avant** tout enrichissement :
  ```python
  from utils.opposition_commerciale import marquer_opposition, filtrer_contactables
  await marquer_opposition(state["prospects"], budget_credits=...)
  state["prospects"] = filtrer_contactables(state["prospects"])
  ```
- **Documenter dans `docs/LEGAL.md`** — le document ne mentionne pas encore cette
  opposition. À faire dans une PR de doc séparée, avec les autres corrections légales
  signalées en #75.
