### PR TITLE
fix: réintégrer #67 et #74 — fusionnées dans leur branche de base, jamais arrivées sur main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,8 +53,17 @@ INSEE_API_KEY=
 TAVILY_API_KEY=
 # BLOCTEL : OBLIGATOIRE LÉGALEMENT — délai d'obtention 3-5 j ouvrés.
 BLOCTEL_API_KEY=
-# DROPCONTACT : 24€/mois.
+# DROPCONTACT : essai gratuit 50 crédits, puis ~79€/mois en entrée de gamme
+# (le tarif de 24€ qui figurait ici n'est plus d'actualité en 2026).
+# Auth = header 'X-Access-Token', base https://api.dropcontact.com/v1
+# 1 crédit = 1 email TROUVÉ (re-crédité si rien n'est trouvé). Ouverture du
+# compte : adresse email professionnelle requise.
 DROPCONTACT_API_KEY=
+# PAPPERS : API Entreprise (données INPI/RNE publiques, source autorisée par
+# docs/LEGAL.md). Essai gratuit 100 crédits à la création du compte avec une
+# adresse professionnelle. Auth = query param 'api_token'.
+# Solde consultable : GET https://api.pappers.fr/v2/suivi-jetons?api_token=...
+PAPPERS_API_KEY=
 
 # ---------- Paramètres campagne (valeurs d'EXEMPLE uniquement) ----------
 # En production ces critères viennent de la table criteres_ciblage du

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,6 +43,10 @@ class Settings(BaseSettings):
     # ---------- APIs collecte ----------
     insee_api_key: str = ""  # api-sirene/3.11 (header X-INSEE-Api-Key-Integration)
 
+    # ---------- APIs enrichissement ----------
+    pappers_api_key: str = ""      # API Entreprise (auth : query param `api_token`)
+    dropcontact_api_key: str = ""  # emails B2B (auth : header `X-Access-Token`)
+
     # ---------- Qualité des prospects (#68) ----------
     # Au-delà de N établissements actifs à la MÊME adresse, on considère qu'il
     # s'agit d'une société de domiciliation (siège social / boîte aux lettres)

--- a/tests/test_annuaire_entreprises.py
+++ b/tests/test_annuaire_entreprises.py
@@ -126,6 +126,26 @@ async def test_un_siren_une_seule_requete(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_deux_etablissements_meme_siren_ont_tous_leur_raw_data(monkeypatch):
+    """Deux établissements d'une même entreprise partagent le SIREN.
+
+    Constaté en réel (A.C.S AUTOCLEAN SERVICE, 2 établissements) : le second ne
+    recevait que `nom_dirigeant`, sans les prénom/nom séparés dans `raw_data` —
+    donc inexploitable par Dropcontact, qui les attend distincts.
+    """
+    monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    etab1, etab2 = _prospect(), _prospect()   # même SIREN
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE]), appels) as client:
+        await ann.enrichir_dirigeants([etab1, etab2], client)
+    assert len(appels) == 1                    # toujours une seule requête
+    for etab in (etab1, etab2):
+        assert etab.nom_dirigeant == "STÉPHANE LUZINDALALU"
+        d = ann.dirigeant_de(etab)
+        assert d is not None and (d.prenom, d.nom) == ("STÉPHANE", "LUZINDALALU")
+
+
+@pytest.mark.asyncio
 async def test_prospect_sans_siren_ignore(monkeypatch):
     monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
     appels: list[str] = []

--- a/tests/test_annuaire_entreprises.py
+++ b/tests/test_annuaire_entreprises.py
@@ -1,0 +1,176 @@
+"""Tests du lookup dirigeant via l'Annuaire des Entreprises (#67). HTTP mocké."""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from models.prospect import Prospect
+from utils import annuaire_entreprises as ann
+
+CID = uuid.uuid4()
+
+
+def _prospect(siren="428836332", nom="SARL GARAGE DES OEILLETS") -> Prospect:
+    return Prospect(campagne_id=CID, nom_entreprise=nom, siren=siren)
+
+
+def _fiche(siren="428836332", dirigeants=None, **extra) -> dict:
+    fiche = {"siren": siren, "nom_complet": "SARL GARAGE DES OEILLETS",
+             "dirigeants": dirigeants if dirigeants is not None else []}
+    fiche.update(extra)
+    return fiche
+
+
+def _client(fiche, appels=None) -> httpx.AsyncClient:
+    def handler(request):
+        if appels is not None:
+            appels.append(str(request.url))
+        results = [fiche] if fiche is not None else []
+        return httpx.Response(200, json={"results": results, "total_results": len(results)})
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# Données réelles observées le 2026-08-08 sur l'API.
+PERSONNE_PHYSIQUE = {
+    "nom": "LUZINDALALU", "prenoms": "STÉPHANE DOMA YOANNE",
+    "annee_de_naissance": "1993", "date_de_naissance": "1993-10",
+    "qualite": "Président de SAS", "type_dirigeant": "personne physique",
+}
+PERSONNE_MORALE = {
+    "siren": "812334225", "denomination": "GROUPE OPTIMUM HOLDING",
+    "qualite": "Président de SAS", "type_dirigeant": "personne morale",
+}
+NOM_AVEC_PARENTHESES = {
+    "nom": "PEDRO TEIXEIRA (PEDRO TEIXEIRA)", "prenoms": "JOA MANUEL",
+    "qualite": "Gérant", "type_dirigeant": "personne physique",
+}
+
+
+# --- Normalisation ----------------------------------------------------------
+def test_premier_prenom_seulement():
+    """Les enrichisseurs attendent UN prénom, pas l'état civil complet."""
+    assert ann._premier_prenom("STÉPHANE DOMA YOANNE") == "STÉPHANE"
+    assert ann._premier_prenom("") == ""
+
+
+def test_nettoie_les_parentheses():
+    assert ann._nettoyer("PEDRO TEIXEIRA (PEDRO TEIXEIRA)") == "PEDRO TEIXEIRA"
+
+
+# --- Extraction -------------------------------------------------------------
+def test_extrait_personne_physique():
+    d = ann.extraire_dirigeant(_fiche(dirigeants=[PERSONNE_PHYSIQUE]))
+    assert d == ann.Dirigeant("STÉPHANE", "LUZINDALALU", "Président de SAS")
+    assert d.nom_complet == "STÉPHANE LUZINDALALU"
+
+
+def test_ignore_personne_morale():
+    """Une holding dirigeante ne donne pas d'email nominatif."""
+    assert ann.extraire_dirigeant(_fiche(dirigeants=[PERSONNE_MORALE])) is None
+
+
+def test_prend_la_personne_physique_parmi_plusieurs():
+    fiche = _fiche(dirigeants=[PERSONNE_MORALE, PERSONNE_PHYSIQUE])
+    assert ann.extraire_dirigeant(fiche).nom == "LUZINDALALU"
+
+
+def test_aucun_dirigeant():
+    assert ann.extraire_dirigeant(_fiche(dirigeants=[])) is None
+
+
+# --- Enrichissement ---------------------------------------------------------
+@pytest.mark.asyncio
+async def test_renseigne_nom_dirigeant():
+    p = _prospect()
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant == "STÉPHANE LUZINDALALU"
+    d = ann.dirigeant_de(p)
+    assert (d.prenom, d.nom) == ("STÉPHANE", "LUZINDALALU")
+
+
+@pytest.mark.asyncio
+async def test_ne_conserve_pas_la_date_de_naissance():
+    """Minimisation RGPD : la source expose la naissance, on ne la stocke pas."""
+    p = _prospect()
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    stocke = p.raw_data["annuaire"]["dirigeant"]
+    assert set(stocke) == {"prenom", "nom", "qualite"}
+    assert "1993" not in str(stocke)
+
+
+@pytest.mark.asyncio
+async def test_conserve_finances_et_nom_commercial():
+    fiche = _fiche(dirigeants=[PERSONNE_PHYSIQUE],
+                   finances={"2024": {"ca": 0, "resultat_net": 79731}},
+                   siege={"nom_commercial": "GARAGE DU 14E", "liste_enseignes": []})
+    p = _prospect()
+    async with _client(fiche) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.raw_data["annuaire"]["finances"]["2024"]["resultat_net"] == 79731
+    assert p.raw_data["annuaire"]["nom_commercial"] == "GARAGE DU 14E"
+
+
+@pytest.mark.asyncio
+async def test_un_siren_une_seule_requete(monkeypatch):
+    monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(), _prospect(), _prospect()]
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE]), appels) as client:
+        await ann.enrichir_dirigeants(prospects, client)
+    assert len(appels) == 1
+    assert all(p.nom_dirigeant == "STÉPHANE LUZINDALALU" for p in prospects)
+
+
+@pytest.mark.asyncio
+async def test_prospect_sans_siren_ignore(monkeypatch):
+    monkeypatch.setattr(ann, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    p = Prospect(campagne_id=CID, nom_entreprise="SANS SIREN")
+    async with _client(_fiche(), appels) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert appels == []
+    assert p.nom_dirigeant is None
+
+
+@pytest.mark.asyncio
+async def test_siren_different_rejete():
+    """La recherche plein texte peut renvoyer autre chose : on vérifie le SIREN."""
+    p = _prospect(siren="428836332")
+    async with _client(_fiche(siren="999999999", dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant is None
+
+
+# --- Dégradation ------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_api_en_erreur_ne_casse_pas_le_run():
+    def handler(request):
+        return httpx.Response(503, text="indisponible")
+    p = _prospect()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant is None
+    assert "annuaire" not in (p.raw_data or {})
+
+
+@pytest.mark.asyncio
+async def test_raw_data_existant_preserve():
+    p = _prospect()
+    p.raw_data = {"adresseEtablissement": {"numeroVoieEtablissement": "47"}}
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.raw_data["adresseEtablissement"]["numeroVoieEtablissement"] == "47"
+    assert p.raw_data["annuaire"]["dirigeant"]["nom"] == "LUZINDALALU"
+
+
+@pytest.mark.asyncio
+async def test_nom_dirigeant_existant_non_ecrase():
+    p = _prospect()
+    p.nom_dirigeant = "SAISI A LA MAIN"
+    async with _client(_fiche(dirigeants=[PERSONNE_PHYSIQUE])) as client:
+        await ann.enrichir_dirigeants([p], client)
+    assert p.nom_dirigeant == "SAISI A LA MAIN"

--- a/tests/test_opposition_commerciale.py
+++ b/tests/test_opposition_commerciale.py
@@ -1,0 +1,197 @@
+"""Tests du filtre d'opposition à l'utilisation commerciale (#74). HTTP mocké.
+
+L'enjeu de ces tests n'est pas seulement « le champ est bien lu » : c'est que le
+module soit **fermé par défaut**. Un prospect non vérifié ne doit jamais devenir
+contactable, quelle que soit la panne (API KO, clé absente, budget épuisé).
+"""
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from config.settings import Settings
+from models.prospect import Prospect
+from utils import opposition_commerciale as oc
+
+CID = uuid.uuid4()
+
+# SIREN réels issus de nos mesures (août 2026). Le modèle Prospect (#10) valide
+# le checksum Luhn : des numéros inventés seraient rejetés à la construction.
+SIRENS = [
+    "322521774",  # BAYARD AUTOMOBILE   — opposée en réel
+    "107159691",  # INTEGRAL PARE BRISE — opposée en réel
+    "331816140",  # DM MOTORS           — non opposée
+    "340505346",  # HUGUES MIHEL        — non opposée
+    "313215444",  # GILBERT SERVANS     — non opposée
+]
+
+
+def _prospect(siren=SIRENS[0], nom="BAYARD AUTOMOBILE") -> Prospect:
+    return Prospect(campagne_id=CID, nom_entreprise=nom, siren=siren)
+
+
+def _settings(cle="test-key") -> Settings:
+    return Settings(pappers_api_key=cle)
+
+
+def _client(oppose, appels=None) -> httpx.AsyncClient:
+    """`oppose` : True / False / None (champ absent de la réponse)."""
+    def handler(request):
+        if appels is not None:
+            appels.append(str(request.url))
+        corps = {"siren": "322521774"}
+        if oppose is not None:
+            corps["opposition_utilisation_commerciale"] = oppose
+        return httpx.Response(200, json=corps)
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# --- Lecture du champ --------------------------------------------------------
+@pytest.mark.asyncio
+async def test_entreprise_opposee():
+    p = _prospect()
+    async with _client(True) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert oc.est_oppose(p) is True
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_entreprise_non_opposee():
+    p = _prospect()
+    async with _client(False) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert oc.est_oppose(p) is False
+    assert oc.peut_etre_contacte(p) is True
+
+
+@pytest.mark.asyncio
+async def test_tracabilite_conservee():
+    """Une exclusion doit pouvoir être justifiée : valeur, date, source, base légale."""
+    p = _prospect()
+    async with _client(True) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    bloc = p.raw_data["opposition_commerciale"]
+    assert bloc["oppose"] is True
+    assert bloc["source"] == "pappers/entreprise"
+    assert "R123-232" in bloc["base_legale"]
+    assert bloc["verifie_le"]
+
+
+# --- Fermé par défaut : le coeur du module -----------------------------------
+@pytest.mark.asyncio
+async def test_api_en_erreur_rend_le_prospect_non_contactable():
+    def handler(request):
+        return httpx.Response(500, text="boom")
+    p = _prospect()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert oc.est_oppose(p) is False          # on n'a pas prouvé l'opposition
+    assert oc.peut_etre_contacte(p) is False  # …mais on ne contacte pas pour autant
+
+
+@pytest.mark.asyncio
+async def test_cle_absente_rend_le_prospect_non_contactable():
+    p = _prospect()
+    async with _client(False) as client:
+        await oc.marquer_opposition([p], client, _settings(cle=""))
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_champ_absent_de_la_reponse_ne_conclut_pas():
+    """Pappers pourrait ne pas renvoyer le champ : ce n'est pas une autorisation."""
+    p = _prospect()
+    async with _client(None) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert p.raw_data["opposition_commerciale"]["oppose"] is None
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_prospect_jamais_verifie_non_contactable():
+    """Sans passage par le filtre, aucun prospect n'est contactable."""
+    assert oc.peut_etre_contacte(_prospect()) is False
+    assert oc.est_oppose(_prospect()) is False
+
+
+def test_negation_de_est_oppose_nest_pas_une_autorisation():
+    """Garde-fou explicite contre le contresens `not est_oppose(p)`."""
+    p = _prospect()  # jamais vérifié
+    assert not oc.est_oppose(p)            # tentant…
+    assert not oc.peut_etre_contacte(p)    # …mais c'est bien celui-ci qui décide
+
+
+# --- Budget de crédits -------------------------------------------------------
+@pytest.mark.asyncio
+async def test_budget_epuise_sarrete_sans_rien_autoriser(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(siren=s) for s in SIRENS]
+    async with _client(False, appels) as client:
+        await oc.marquer_opposition(prospects, client, _settings(), budget_credits=2)
+    assert len(appels) == 2                                   # budget respecté
+    assert sum(oc.peut_etre_contacte(p) for p in prospects) == 2
+    # les 3 restants ne sont ni vérifiés ni contactables
+    assert all(not oc.peut_etre_contacte(p) for p in prospects[2:])
+
+
+@pytest.mark.asyncio
+async def test_budget_strict_leve_une_exception(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    prospects = [_prospect(siren=s) for s in SIRENS[:3]]
+    async with _client(False) as client:
+        with pytest.raises(oc.BudgetCreditsEpuise):
+            await oc.marquer_opposition(prospects, client, _settings(),
+                                        budget_credits=1, strict=True)
+
+
+# --- Cache et volumétrie -----------------------------------------------------
+@pytest.mark.asyncio
+async def test_un_siren_une_seule_requete(monkeypatch):
+    """Plusieurs établissements partagent le SIREN : 1 crédit, pas 3."""
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    prospects = [_prospect(), _prospect(), _prospect()]
+    async with _client(True, appels) as client:
+        cache = await oc.marquer_opposition(prospects, client, _settings())
+    assert len(appels) == 1
+    assert len(cache) == 1
+    assert all(oc.est_oppose(p) for p in prospects)
+
+
+@pytest.mark.asyncio
+async def test_prospect_sans_siren_ignore(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    appels: list[str] = []
+    p = Prospect(campagne_id=CID, nom_entreprise="SANS SIREN")
+    async with _client(False, appels) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert appels == []
+    assert oc.peut_etre_contacte(p) is False
+
+
+@pytest.mark.asyncio
+async def test_filtrer_contactables(monkeypatch):
+    monkeypatch.setattr(oc, "MIN_INTERVAL_S", 0)
+    autorise, refuse = _prospect(siren=SIRENS[2]), _prospect(siren=SIRENS[0])
+
+    def handler(request):
+        oppose = "322521774" in str(request.url)
+        return httpx.Response(200, json={"opposition_utilisation_commerciale": oppose})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await oc.marquer_opposition([autorise, refuse], client, _settings())
+    assert oc.filtrer_contactables([autorise, refuse]) == [autorise]
+
+
+@pytest.mark.asyncio
+async def test_raw_data_existant_preserve():
+    p = _prospect()
+    p.raw_data = {"domiciliation": {"etablissements_a_cette_adresse": 8}}
+    async with _client(False) as client:
+        await oc.marquer_opposition([p], client, _settings())
+    assert p.raw_data["domiciliation"]["etablissements_a_cette_adresse"] == 8
+    assert p.raw_data["opposition_commerciale"]["oppose"] is False

--- a/utils/annuaire_entreprises.py
+++ b/utils/annuaire_entreprises.py
@@ -128,6 +128,11 @@ async def enrichir_dirigeants(
     """
     prospects = list(prospects)
     cache: dict[str, Dirigeant | None] = {}
+    # Charge utile mémoïsée par SIREN : deux établissements d'une même entreprise
+    # partagent le SIREN, et tous deux doivent recevoir `raw_data['annuaire']`
+    # (sinon le second se retrouve avec `nom_dirigeant` mais sans prénom/nom
+    # séparés — constaté en réel sur deux établissements A.C.S AUTOCLEAN SERVICE).
+    charges: dict[str, dict] = {}
 
     ferme_client = client is None
     client = client or httpx.AsyncClient()
@@ -144,20 +149,22 @@ async def enrichir_dirigeants(
                 resultat = await chercher_par_siren(siren, client)
                 if resultat is None:
                     continue
-                cache[siren] = extraire_dirigeant(resultat)
+                dirigeant = extraire_dirigeant(resultat)
+                cache[siren] = dirigeant
+                charges[siren] = {
+                    # Minimisation RGPD : ni date ni année de naissance.
+                    "dirigeant": (
+                        {"prenom": dirigeant.prenom, "nom": dirigeant.nom,
+                         "qualite": dirigeant.qualite}
+                        if dirigeant else None
+                    ),
+                    "nom_commercial": _nom_commercial(resultat),
+                    "finances": resultat.get("finances"),
+                    "at": datetime.now(timezone.utc).isoformat(),
+                }
+            if siren in charges:
                 prospect.raw_data = {
-                    **(prospect.raw_data or {}),
-                    "annuaire": {
-                        # Minimisation RGPD : ni date ni année de naissance.
-                        "dirigeant": (
-                            {"prenom": cache[siren].prenom, "nom": cache[siren].nom,
-                             "qualite": cache[siren].qualite}
-                            if cache[siren] else None
-                        ),
-                        "nom_commercial": _nom_commercial(resultat),
-                        "finances": resultat.get("finances"),
-                        "at": datetime.now(timezone.utc).isoformat(),
-                    },
+                    **(prospect.raw_data or {}), "annuaire": charges[siren],
                 }
             dirigeant = cache.get(siren)
             if dirigeant and not prospect.nom_dirigeant:

--- a/utils/annuaire_entreprises.py
+++ b/utils/annuaire_entreprises.py
@@ -1,0 +1,182 @@
+"""Récupération du dirigeant via l'Annuaire des Entreprises (#67).
+
+`Prospect.nom_dirigeant` existe (#10) mais n'était jamais renseigné : **l'API
+Sirene ne renvoie pas les dirigeants**. Or c'est un prérequis dur pour
+Dropcontact (#21), qui exige au minimum `first_name + last_name + company`.
+
+Source : `recherche-entreprises.api.gouv.fr` (Annuaire des Entreprises, DINUM) —
+gratuite, sans clé, officielle, et déjà autorisée par `docs/LEGAL.md` § « annuaires
+professionnels publics » (règle #2).
+
+⚠️ **Cette API ne remplace pas Sirene** : identité, NAF, adresse et effectif font
+double emploi avec la collecte (#15). On l'utilise en **lookup ciblé par SIREN**,
+uniquement pour ce que Sirene n'a pas :
+- `dirigeants[]` — nom et prénom du dirigeant personne physique ;
+- `finances` — CA / résultat net (signal de santé, conservé pour le scoring #24) ;
+- `nom_commercial` / `liste_enseignes` — nom d'usage, parfois plus « cherchable »
+  que la raison sociale (mesuré : ~1 garage sur 8 seulement).
+
+Elle ne contient **aucune donnée de contact** (ni site web, ni email, ni téléphone)
+— vérifié en direct : elle ne résout donc pas l'enrichissement à elle seule.
+
+RGPD — minimisation : la réponse expose la date et l'année de naissance des
+dirigeants. On ne les conserve **pas** : seuls prénom, nom et qualité sont utiles à
+la prospection B2B. Voir aussi #65 pour le cas des entreprises individuelles, où le
+dirigeant se confond avec l'entreprise.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Iterable, NamedTuple
+
+import httpx
+
+from models.prospect import Prospect
+
+logger = logging.getLogger(__name__)
+
+API_URL = "https://recherche-entreprises.api.gouv.fr/search"
+MIN_INTERVAL_S = 0.2  # API publique sans clé — on reste poli sur le débit
+UA = "agent-prospection-b2b/0.1 (+https://github.com/95902/Agent-IA-de-prospection-B2B-)"
+
+
+class Dirigeant(NamedTuple):
+    prenom: str
+    nom: str
+    qualite: str | None = None
+
+    @property
+    def nom_complet(self) -> str:
+        return f"{self.prenom} {self.nom}".strip()
+
+
+def _nettoyer(valeur: str) -> str:
+    """Retire les parenthèses de l'état civil et normalise les espaces.
+
+    Les données réelles contiennent des doublons entre parenthèses, ex.
+    « PEDRO TEIXEIRA (PEDRO TEIXEIRA) ».
+    """
+    return re.sub(r"\s+", " ", re.sub(r"\([^)]*\)", " ", valeur or "")).strip()
+
+
+def _premier_prenom(prenoms: str) -> str:
+    """« STÉPHANE DOMA YOANNE » -> « STÉPHANE ».
+
+    Les enrichisseurs attendent un prénom unique ; envoyer la liste complète
+    dégrade le taux de correspondance.
+    """
+    nettoye = _nettoyer(prenoms)
+    return nettoye.split(" ")[0] if nettoye else ""
+
+
+def extraire_dirigeant(resultat: dict) -> Dirigeant | None:
+    """Premier dirigeant **personne physique** exploitable, sinon None.
+
+    Les personnes morales (ex. « GROUPE OPTIMUM HOLDING », `type_dirigeant`
+    = `personne morale`) sont ignorées : on ne peut pas en tirer un email
+    nominatif.
+    """
+    for brut in (resultat.get("dirigeants") or []):
+        if brut.get("type_dirigeant") == "personne morale" or brut.get("denomination"):
+            continue
+        prenom = _premier_prenom(brut.get("prenoms") or "")
+        nom = _nettoyer(brut.get("nom") or "")
+        if prenom and nom:
+            return Dirigeant(prenom, nom, brut.get("qualite"))
+    return None
+
+
+def _nom_commercial(resultat: dict) -> str | None:
+    siege = resultat.get("siege") or {}
+    enseignes = siege.get("liste_enseignes") or []
+    return siege.get("nom_commercial") or (enseignes[0] if enseignes else None)
+
+
+async def chercher_par_siren(
+    siren: str, client: httpx.AsyncClient
+) -> dict | None:
+    """Fiche Annuaire des Entreprises pour ce SIREN. None si absente ou API KO."""
+    try:
+        resp = await client.get(
+            API_URL,
+            params={"q": siren, "per_page": 1},
+            headers={"User-Agent": UA},
+            timeout=20.0,
+        )
+        resp.raise_for_status()
+        resultats = resp.json().get("results") or []
+    except Exception as exc:  # une fiche manquante ne casse pas le run
+        logger.warning("annuaire-entreprises KO (%s) : %s", siren, exc)
+        return None
+    for resultat in resultats:
+        if str(resultat.get("siren") or "") == str(siren):
+            return resultat
+    return None
+
+
+async def enrichir_dirigeants(
+    prospects: Iterable[Prospect], client: httpx.AsyncClient | None = None
+) -> dict[str, Dirigeant | None]:
+    """Renseigne `nom_dirigeant` depuis l'Annuaire des Entreprises.
+
+    Écrit aussi `raw_data['annuaire']` : prénom/nom séparés (attendus tels quels
+    par Dropcontact), qualité, nom commercial et finances. Retourne le cache
+    {siren: dirigeant} pour inspection et tests.
+    """
+    prospects = list(prospects)
+    cache: dict[str, Dirigeant | None] = {}
+
+    ferme_client = client is None
+    client = client or httpx.AsyncClient()
+    try:
+        premier = True
+        for prospect in prospects:
+            siren = prospect.siren
+            if not siren:
+                continue
+            if siren not in cache:
+                if not premier:
+                    await asyncio.sleep(MIN_INTERVAL_S)
+                premier = False
+                resultat = await chercher_par_siren(siren, client)
+                if resultat is None:
+                    continue
+                cache[siren] = extraire_dirigeant(resultat)
+                prospect.raw_data = {
+                    **(prospect.raw_data or {}),
+                    "annuaire": {
+                        # Minimisation RGPD : ni date ni année de naissance.
+                        "dirigeant": (
+                            {"prenom": cache[siren].prenom, "nom": cache[siren].nom,
+                             "qualite": cache[siren].qualite}
+                            if cache[siren] else None
+                        ),
+                        "nom_commercial": _nom_commercial(resultat),
+                        "finances": resultat.get("finances"),
+                        "at": datetime.now(timezone.utc).isoformat(),
+                    },
+                }
+            dirigeant = cache.get(siren)
+            if dirigeant and not prospect.nom_dirigeant:
+                prospect.nom_dirigeant = dirigeant.nom_complet
+    finally:
+        if ferme_client:
+            await client.aclose()
+
+    trouves = sum(1 for p in prospects if p.nom_dirigeant)
+    logger.info(
+        "annuaire : %d/%d prospects avec dirigeant (%d SIREN interrogés)",
+        trouves, len(prospects), len(cache),
+    )
+    return cache
+
+
+def dirigeant_de(prospect: Prospect) -> Dirigeant | None:
+    """Prénom/nom séparés depuis `raw_data` — format attendu par Dropcontact."""
+    brut = (prospect.raw_data or {}).get("annuaire", {}).get("dirigeant")
+    if not brut:
+        return None
+    return Dirigeant(brut.get("prenom", ""), brut.get("nom", ""), brut.get("qualite"))

--- a/utils/opposition_commerciale.py
+++ b/utils/opposition_commerciale.py
@@ -1,0 +1,201 @@
+"""Opposition à l'utilisation commerciale des données (#74) — filtre LÉGAL.
+
+Une entreprise peut **s'opposer formellement à l'utilisation commerciale de ses
+données** (art. R123-232 du code de commerce), choix exprimé au Guichet Unique lors
+de l'immatriculation ou via le RNE. C'est un opt-out enregistré, pas une zone
+grise : démarcher ces entreprises est précisément ce que ce droit interdit.
+
+Mesuré sur 35 entreprises réelles (Paris, août 2026) : **17 opposées, soit 49 %**.
+Et le taux grimpe à **87 % pour les SIREN récents** (immatriculés via le Guichet
+Unique depuis 2023) contre 20 % pour les anciens — il augmentera donc mécaniquement
+à mesure que le stock d'entreprises se renouvelle.
+
+Source : **aucune source gratuite n'expose ce champ.** Vérifié : `statut_diffusion`
+(Sirene et annuaire-entreprises) vaut `O` pour les opposées comme pour les autres —
+ce n'est pas le même concept. Seul Pappers le renvoie, sur `/entreprise`, **par
+défaut** : coût = l'appel de base, soit **1 crédit par entreprise**.
+
+## Le principe : fermé par défaut
+
+Ne pas savoir n'est pas une autorisation. Si l'API est indisponible, si la clé
+manque ou si le budget de crédits est épuisé, le prospect reste **non vérifié** —
+et un prospect non vérifié n'est **pas** contactable. D'où deux fonctions
+distinctes, volontairement dissymétriques :
+
+    est_oppose(p)         -> True seulement si on a VÉRIFIÉ qu'il est opposé
+    peut_etre_contacte(p) -> True seulement si on a VÉRIFIÉ qu'il ne l'est pas
+
+Utiliser `peut_etre_contacte()` comme garde avant tout envoi vers un enrichisseur
+tiers ou toute file de contact. `not est_oppose()` n'est PAS équivalent : cette
+expression laisserait passer les prospects non vérifiés.
+
+Traçabilité : la valeur et la date de vérification sont conservées dans
+`raw_data['opposition_commerciale']`, pour pouvoir justifier une exclusion — ou une
+non-exclusion — en cas de contrôle.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Iterable
+
+import httpx
+
+from config.settings import Settings, get_settings
+from models.prospect import Prospect
+
+logger = logging.getLogger(__name__)
+
+PAPPERS_BASE = "https://api.pappers.fr/v2"
+MIN_INTERVAL_S = 0.3     # API payante, mais restons polis
+COUT_CREDITS_PAR_SIREN = 1
+
+
+class BudgetCreditsEpuise(RuntimeError):
+    """Levée uniquement si `strict=True` — sinon on s'arrête proprement."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def solde_credits(client: httpx.AsyncClient, settings: Settings) -> int | None:
+    """Crédits Pappers restants. None si indisponible."""
+    try:
+        resp = await client.get(
+            f"{PAPPERS_BASE}/suivi-jetons",
+            params={"api_token": settings.pappers_api_key},
+            timeout=20.0,
+        )
+        resp.raise_for_status()
+        return resp.json().get("jetons_pay_as_you_go_restants")
+    except Exception as exc:
+        logger.warning("solde Pappers indisponible : %s", exc)
+        return None
+
+
+async def verifier_opposition(
+    siren: str, client: httpx.AsyncClient, settings: Settings
+) -> bool | None:
+    """`True` = opposée, `False` = non opposée, `None` = **non vérifiable**.
+
+    Le `None` est significatif : il ne veut pas dire « autorisée », il veut dire
+    qu'on ne sait pas — et dans ce cas on ne contacte pas.
+    """
+    if not settings.pappers_api_key:
+        logger.warning("pappers_api_key absente — opposition non vérifiable")
+        return None
+    try:
+        resp = await client.get(
+            f"{PAPPERS_BASE}/entreprise",
+            params={"api_token": settings.pappers_api_key, "siren": siren},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        valeur = resp.json().get("opposition_utilisation_commerciale")
+    except Exception as exc:
+        logger.warning("opposition non vérifiable (%s) : %s", siren, exc)
+        return None
+    # Champ absent de la réponse -> on ne conclut pas.
+    return bool(valeur) if valeur is not None else None
+
+
+async def marquer_opposition(
+    prospects: Iterable[Prospect],
+    client: httpx.AsyncClient | None = None,
+    settings: Settings | None = None,
+    budget_credits: int | None = None,
+    strict: bool = False,
+) -> dict[str, bool | None]:
+    """Vérifie l'opposition commerciale de chaque prospect et l'inscrit dans
+    `raw_data['opposition_commerciale']`.
+
+    `budget_credits` borne le nombre de SIREN interrogés (1 crédit chacun). Une
+    fois le budget atteint, on **s'arrête** : les prospects restants ne sont pas
+    vérifiés, donc pas contactables — jamais l'inverse. Sans budget explicite, tous
+    les SIREN distincts sont interrogés, ce qui peut coûter cher sur une grosse
+    campagne : à câbler avec le suivi de coûts (#23).
+
+    `strict=True` lève `BudgetCreditsEpuise` au lieu de s'arrêter silencieusement.
+
+    Retourne le cache {siren: opposé} pour inspection et tests.
+    """
+    settings = settings or get_settings()
+    prospects = list(prospects)
+    cache: dict[str, bool | None] = {}
+    interroges = 0
+
+    ferme_client = client is None
+    client = client or httpx.AsyncClient()
+    try:
+        for prospect in prospects:
+            siren = prospect.siren
+            if not siren:
+                continue
+            if siren not in cache:
+                if budget_credits is not None and interroges >= budget_credits:
+                    message = (
+                        f"budget de {budget_credits} crédit(s) atteint — "
+                        f"{len(prospects) - len(cache)} prospect(s) non vérifiés, "
+                        "donc non contactables"
+                    )
+                    if strict:
+                        raise BudgetCreditsEpuise(message)
+                    logger.warning(message)
+                    break
+                if interroges:
+                    await asyncio.sleep(MIN_INTERVAL_S)
+                cache[siren] = await verifier_opposition(siren, client, settings)
+                interroges += 1
+            prospect.raw_data = {
+                **(prospect.raw_data or {}),
+                "opposition_commerciale": {
+                    "oppose": cache[siren],
+                    "verifie_le": _now(),
+                    "source": "pappers/entreprise",
+                    "base_legale": "art. R123-232 code de commerce",
+                },
+            }
+    finally:
+        if ferme_client:
+            await client.aclose()
+
+    opposes = sum(1 for v in cache.values() if v is True)
+    inconnus = sum(1 for v in cache.values() if v is None)
+    contactables = sum(1 for p in prospects if peut_etre_contacte(p))
+    logger.info(
+        "opposition commerciale : %d opposé(s), %d non vérifiable(s), "
+        "%d/%d prospect(s) contactables — %d crédit(s) consommés",
+        opposes, inconnus, contactables, len(prospects),
+        interroges * COUT_CREDITS_PAR_SIREN,
+    )
+    return cache
+
+
+def _verdict(prospect: Prospect) -> bool | None:
+    bloc = (prospect.raw_data or {}).get("opposition_commerciale")
+    return bloc.get("oppose") if isinstance(bloc, dict) else None
+
+
+def est_oppose(prospect: Prospect) -> bool:
+    """True **seulement** si la vérification a conclu à une opposition.
+
+    ⚠️ Ne pas utiliser `not est_oppose(p)` comme autorisation de contact : un
+    prospect non vérifié renverrait False ici. Utiliser `peut_etre_contacte()`.
+    """
+    return _verdict(prospect) is True
+
+
+def peut_etre_contacte(prospect: Prospect) -> bool:
+    """True **seulement** si on a vérifié que le prospect n'est pas opposé.
+
+    C'est la garde à utiliser avant tout envoi vers un enrichisseur tiers ou toute
+    file de contact. Non vérifié -> False (fermé par défaut).
+    """
+    return _verdict(prospect) is False
+
+
+def filtrer_contactables(prospects: Iterable[Prospect]) -> list[Prospect]:
+    """Ne garde que les prospects dont la non-opposition est **vérifiée**."""
+    return [p for p in prospects if peut_etre_contacte(p)]


### PR DESCRIPTION
## ⚠️ Deux PR fusionnées ne sont jamais arrivées sur `main`

Les PR **#73 (#67 dirigeants)** et **#76 (#74 opposition commerciale)** apparaissent
comme « merged » sur GitHub, mais **leur contenu est absent de `main`**.

Cause : c'étaient des **PR empilées**. Leur base n'était pas `main` mais la branche
précédente de la chaîne :

```
#66  base=main                              -> arrivé sur main  ✅
#70  base=main                              -> arrivé sur main  ✅
#73  base=sprint-2/issue-68-domiciliation   -> fusionné dans cette branche  ❌
#76  base=sprint-2/issue-67-dirigeants      -> fusionné dans cette branche  ❌
```

Comme #70 avait **déjà** fusionné `issue-68-domiciliation` dans `main` avant que #73
n'y soit fusionnée, le contenu de #73 (puis de #76) a atterri sur des branches qui
n'alimentent plus rien. Vérifiable : `git merge-base --is-ancestor <merge-commit>
origin/main` répond non pour #73 et #76.

**C'est ma responsabilité** : j'ai empilé les PR pour garder des diffs lisibles à la
relecture, sans signaler assez clairement qu'elles devaient être fusionnées **dans
l'ordre** (#70, puis #73, puis #76). Fusionnées dans le désordre, elles se perdent
silencieusement — aucune erreur, aucun conflit, la PR s'affiche simplement « merged ».

## Ce qui manquait au produit

| Fichier | Issue | Enjeu |
|---|---|---|
| `utils/opposition_commerciale.py` | #74 | **Filtre légal** (art. R123-232) — 49 % des prospects mesurés sont opposés à l'utilisation commerciale |
| `utils/annuaire_entreprises.py` | #67 | Nom du dirigeant (93 % de couverture, source gratuite) |
| `config/settings.py` | — | Clés `pappers_api_key` et `dropcontact_api_key` |
| `.env.example` | — | Documentation des deux clés + tarif Dropcontact corrigé |
| tests associés | — | 30 tests |

Le plus gênant est le premier : **l'équipe pouvait légitimement croire le filtre légal
livré**, alors qu'aucun prospect n'était filtré.

## Cette PR

Rejoue les 4 commits orphelins sur `main` à jour. Fusion **sans conflit** ; les quatre
clés d'API coexistent correctement dans `config/settings.py` après reprise du
`tavily_api_key` ajouté entre-temps par #66.

**165 tests passent** (135 sur `main` + 30 réintégrés). Aucun appel réseau dans les tests.

Le diff est exactement celui des deux PR d'origine — rien n'a été ajouté au passage.

## Pour éviter que ça se reproduise

Deux options, au choix de l'équipe :
- **ne plus empiler** : une PR = une base `main`, quitte à avoir des diffs qui se
  recouvrent à la relecture ;
- **garder l'empilement mais fusionner dans l'ordre**, en le disant explicitement dans
  la description de chaque PR empilée (GitHub recible automatiquement la base *si* la
  PR parente est fusionnée en premier).

Je penche pour la première : le gain de lisibilité ne vaut pas le risque de perdre du
code silencieusement, surtout sur du code de conformité.
