### PR TITLE
#65 Accepter les emails génériques commerciaux (D1)

### DIFF
--- a/agents/enrichissement_agent.py
+++ b/agents/enrichissement_agent.py
@@ -6,10 +6,12 @@ Ce node les enrichit via une **cascade de résolveurs** de sources légales
 
     Tavily (recherche + contenu)  →  Crawl4AI (rendu JS du site)  →  DuckDuckGo
 
-Produit orienté **email-first** (l'appel = Phase 2). La politique email de #10
-est conservée telle quelle (`contact@`/`info@` restent mis à None sur
-`Prospect.email`), MAIS **tous** les contacts bruts trouvés sont stockés dans
-`raw_data['enrichissement']` — terrain de test pour un futur réalignement RGPD.
+Produit orienté **email-first** (l'appel = Phase 2). Depuis #65 (décision D1),
+les boîtes génériques COMMERCIALES (`contact@`, `info@`, `reservation@`…) sont
+acceptées sur `Prospect.email` ; seules les boîtes RGPD (`dpo@`, `rgpd@`…) et
+automatiques (`noreply@`) restent écartées (`models/prospect.py`). Dans tous les
+cas, **tous** les contacts bruts trouvés sont aussi stockés dans
+`raw_data['enrichissement']`.
 
 ⚠️ Précision : un email/téléphone glané au hasard dans des résultats de recherche
 appartient souvent à une AUTRE entreprise. On applique donc un **filtre par

--- a/models/prospect.py
+++ b/models/prospect.py
@@ -20,11 +20,28 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from stdnum.fr import siren as _stdnum_siren
 from stdnum.fr import siret as _stdnum_siret
 
-# Emails à écarter (score email = 0) — cf. docs/SCORING.md. Mélange de domaines
-# et de préfixes de partie locale : matching par sous-chaîne, insensible casse.
+# Domaines/hôtes à écarter (score email = 0) : jamais le domaine propre d'une
+# entreprise (annuaires, opérateurs, boîtes automatiques). Matching par
+# sous-chaîne sur le DOMAINE uniquement, insensible à la casse. Cf. docs/SCORING.md.
 EMAIL_BLACKLIST_DOMAINS = (
-    "pagesjaunes.fr", "laposte.net", "noreply.", "contact@", "info@", "mairie.",
+    "pagesjaunes.fr", "laposte.net", "noreply.", "mairie.",
 )
+
+# Rôles de boîte à écarter même sur le domaine propre de l'entreprise, comparés
+# à la PARTIE LOCALE tokenisée (séparateurs . - _ +) — jamais par sous-chaîne,
+# pour éviter les faux positifs (« dupont » contient « dpo »). Deux familles :
+# - automatiques (noreply/no-reply) : personne ne les lit ;
+# - RGPD/juridiques (dpo, rgpd, cnil, données personnelles…) : prospecter le DPO
+#   d'une société est le pire destinataire possible — mesuré en réel (issue #65).
+# À l'inverse, les génériques COMMERCIALES (contact@, info@, reservation@,
+# bonjour@, reception@…) sont désormais CONSERVÉES — décision équipe D1 / #65 :
+# elles représentent ~30 % des emails trouvés par la chaîne gratuite.
+EMAIL_BLACKLIST_ROLES = frozenset({
+    "noreply", "reply",
+    "dpo", "rgpd", "cnil", "privacy", "personnelles",
+})
+
+_LOCALPART_SEP = re.compile(r"[.\-_+]")
 
 # Statuts autorisés (CHECK de la table prospects).
 STATUTS_PROSPECT = (
@@ -57,12 +74,21 @@ def _normalize_phone(raw: str) -> str | None:
 
 
 def _clean_email(raw: str) -> str | None:
-    """Email normalisé, ou None si syntaxe invalide ou domaine blacklisté."""
+    """Email normalisé, ou None si : syntaxe invalide, domaine hors-entreprise
+    (annuaires/opérateurs/auto), ou boîte de rôle à écarter (automatique / RGPD).
+
+    Les génériques commerciales (contact@, info@, reservation@…) sont CONSERVÉES
+    — décision équipe D1 / #65. Seules les boîtes RGPD (dpo@, rgpd@, cnil@,
+    donnees.personnelles@) et automatiques (noreply@) sont écartées côté rôle."""
     try:
         normalized = validate_email(raw, check_deliverability=False).normalized
     except EmailNotValidError:
         return None
-    if any(token in normalized.lower() for token in EMAIL_BLACKLIST_DOMAINS):
+    local, _, domain = normalized.lower().partition("@")
+    if any(token in domain for token in EMAIL_BLACKLIST_DOMAINS):
+        return None
+    tokens = {t for t in _LOCALPART_SEP.split(local) if t}
+    if tokens & EMAIL_BLACKLIST_ROLES:
         return None
     return normalized
 

--- a/tests/test_enrichissement.py
+++ b/tests/test_enrichissement.py
@@ -71,15 +71,29 @@ async def test_valid_contact_set_on_prospect(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_generic_email_kept_in_rawdata_but_nulled(monkeypatch):
-    # contact@ : politique #10 -> None sur .email, MAIS gardé dans raw_data.
+async def test_generic_commercial_email_kept(monkeypatch):
+    # #65 / D1 : contact@ (générique commerciale) est désormais accepté sur
+    # .email, et toujours conservé dans raw_data.
     monkeypatch.setattr(ea, "RESOLVERS", [_fixed_resolver(
         Contacts(emails=["contact@garage.fr"], phones=[], source="tavily")
     )])
     p = _p()
     await ea._enrich_prospect(p, None, ea.get_settings())
-    assert p.email is None
+    assert p.email == "contact@garage.fr"
     assert "contact@garage.fr" in p.raw_data["enrichissement"]["emails"]
+
+
+@pytest.mark.asyncio
+async def test_rgpd_email_nulled_but_kept_in_rawdata(monkeypatch):
+    # Une boîte RGPD (dpo@) reste mise à None sur .email — pire destinataire —
+    # mais est conservée dans raw_data pour traçabilité.
+    monkeypatch.setattr(ea, "RESOLVERS", [_fixed_resolver(
+        Contacts(emails=["dpo@garage.fr"], phones=[], source="tavily")
+    )])
+    p = _p()
+    await ea._enrich_prospect(p, None, ea.get_settings())
+    assert p.email is None
+    assert "dpo@garage.fr" in p.raw_data["enrichissement"]["emails"]
 
 
 # --- Cascade ----------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,17 +51,48 @@ def test_email_valide_conserve():
 @pytest.mark.parametrize(
     "raw",
     [
-        "notanemail",            # pas de @
-        "a@b",                   # domaine sans point
-        "contact@garage.fr",     # préfixe blacklisté
-        "info@x.fr",             # préfixe blacklisté
-        "x@pagesjaunes.fr",      # domaine blacklisté
-        "x@laposte.net",         # domaine blacklisté
-        "no-reply@noreply.io",   # 'noreply.' blacklisté
+        "contact@garage.fr",       # générique commerciale
+        "info@garage.fr",          # générique commerciale
+        "reservation@hotel.fr",    # générique commerciale
+        "bonjour@studio.fr",       # générique commerciale
+        "reception@hotel.fr",      # générique commerciale
+    ],
+)
+def test_email_generique_commerciale_conservee(raw):
+    # Décision D1 / #65 : les boîtes génériques commerciales sont valides.
+    assert _prospect(email=raw).email == raw
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "notanemail",                    # pas de @
+        "a@b",                           # domaine sans point
+        "x@pagesjaunes.fr",              # domaine blacklisté
+        "x@laposte.net",                 # domaine blacklisté
+        "no-reply@noreply.io",           # domaine 'noreply.'
+        "noreply@garage.fr",             # rôle automatique (domaine propre)
+        "dpo@garage.fr",                 # boîte RGPD
+        "rgpd@garage.fr",                # boîte RGPD
+        "donnees.personnelles@x.fr",     # boîte RGPD (partie locale composée)
+        "cnil@x.fr",                     # boîte RGPD
     ],
 )
 def test_email_invalide_ou_blackliste_vers_none(raw):
     assert _prospect(email=raw).email is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "adpont@garage.fr",          # 'adpont' contient la sous-chaîne 'dpo'
+        "prrgpdupuis@cabinet.fr",    # contient 'rgpd' en sous-chaîne
+    ],
+)
+def test_email_role_pas_de_faux_positif_par_sous_chaine(raw):
+    # La comparaison se fait par token (partie locale scindée sur . - _ +),
+    # jamais par sous-chaîne : un rôle noyé dans un mot ne déclenche rien.
+    assert _prospect(email=raw).email == raw
 
 
 # --- SIRET : Luhn strict ----------------------------------------------------


### PR DESCRIPTION
Closes #65. Base `main`, aucun empilement (règle retenue après l'incident des PR empilées).

## Contexte
Décision équipe **D1 (14 août)** : accepter les emails génériques. La chaîne gratuite ne trouve que des boîtes génériques (`contact@`, `reservation@`, `info@`, `bonjour@`, `reception@`) — mesuré à ~30 % des emails trouvés. Or `models/prospect.py::_clean_email` les mettait à `None` → ces 30 % valaient 0.

## Ce que fait la PR
- **`EMAIL_BLACKLIST_DOMAINS`** : retire `contact@`/`info@` (qui n'étaient pas des domaines) ; ne compare plus que le **domaine** (annuaires/opérateurs : `pagesjaunes.fr`, `laposte.net`, `noreply.`, `mairie.`).
- **`EMAIL_BLACKLIST_ROLES`** (nouveau) : comparé à la **partie locale tokenisée** (`. - _ +`), jamais par sous-chaîne — pour éviter les faux positifs (un rôle noyé dans un nom propre ne déclenche rien). Écarte :
  - boîtes **RGPD/juridiques** : `dpo@`, `rgpd@`, `cnil@`, `donnees.personnelles@`, `privacy@` — **pires destinataires** possibles pour de la prospection (mesuré en réel) ;
  - boîtes **automatiques** : `noreply@`, `no-reply@`.
- **Conservés** : génériques commerciales **et** emails personnels (`jean.dupont@`).

## Choix de conception
Une liste **blanche** de rôles aurait rejeté les emails **personnels** — les meilleurs contacts. Le bon modèle pour un gate reste une liste noire, mais scindée proprement : domaine hors-entreprise d'un côté, rôle toxique de l'autre.

## Tests
`tests/test_models.py` + `tests/test_enrichissement.py` mis à jour (génériques conservées, RGPD/auto écartées, garde anti-sous-chaîne). **176 passent, 2 skippés** (intégration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

