### PR TITLE
#21 Dropcontact : fallback email payant (garde opposition + API réelle)

### DIFF
--- a/docs/issues/sprint-2/21-integrer-dropcontact-enrichissement-emails-b2b.md
+++ b/docs/issues/sprint-2/21-integrer-dropcontact-enrichissement-emails-b2b.md
@@ -17,22 +17,25 @@ Compléter l'enrichissement email (#18) via Dropcontact quand Tavily/Crawl4AI n'
 ## Fichier
 `utils/dropcontact.py`
 
-## Flow
-- [ ] `POST /batch` avec les prospects éligibles → récupération d'un `request_id`
-- [ ] Polling toutes les 5s jusqu'à disponibilité du résultat (avec timeout raisonnable et gestion d'erreur)
-- [ ] Upsert de l'email trouvé sur le prospect concerné
+## Flow (API réelle — spec d'origine corrigée)
+- [x] `POST https://api.dropcontact.com/v1/enrich/all` (corps `{"data":[...],"siren":true}`, header `X-Access-Token`) → `request_id`
+- [x] Polling `GET /v1/enrich/all/{request_id}` jusqu'à `success:true` (timeout + gestion d'erreur, jamais bloquant)
+- [x] Upsert de l'email trouvé (appariement par ordre de réponse)
 
-## Condition d'appel (pour maîtriser le coût — 24€/mois pour ~1000 enrichissements)
+## Condition d'appel (corrigée — website NON requis, garde légale ajoutée)
 ```
-email IS None ET nom_dirigeant IS NOT None ET site_web IS NOT None
+email IS None  ET  nom_dirigeant IS NOT None  ET  peut_etre_contacte(p)
 ```
+`site_web IS NOT None` retiré : jamais vrai en pratique (0 % de sites obtenus) et inutile — Dropcontact matche sans domaine. `nom_dirigeant` désormais peuplé par #67. Website envoyé s'il existe, en bonus.
 
 ## Contraintes
-- Dropcontact génère l'email algorithmiquement (prénom.nom@entreprise.fr), certifié RGPD et hébergé en Europe — ne pas appeler ce service hors de la condition ci-dessus (voir `docs/LEGAL.md`)
-- Logger le nombre d'appels Dropcontact par campagne pour suivre le coût (voir #23)
+- **Garde légale** : n'interroger Dropcontact que pour les prospects vérifiés non opposés (`peut_etre_contacte()`) — le nettoyage #19 tourne avant. Envoyer un prospect opposé chez un enrichisseur tiers est interdit (art. R123-232).
+- Pay on success : les échecs ne coûtent rien ; `budget` plafonne quand même la dépense.
+- Compteurs {eligibles, soumis, emails} exposés pour le suivi de coût (#23).
 
 ## Critères d'acceptance
-- [ ] Seuls les prospects respectant la condition d'appel déclenchent une requête Dropcontact
-- [ ] Le taux d'enrichissement email global (Tavily + Crawl4AI + Dropcontact) atteint la cible PRD (≥20%)
+- [x] Seuls les prospects respectant la condition d'appel déclenchent une requête
+- [x] Aucun prospect opposé (ou non vérifié) n'est soumis
+- [ ] Taux email global (chaîne gratuite + Dropcontact) ≥ 20 % PRD — mesure live (ops)
 
 

--- a/tests/test_dropcontact.py
+++ b/tests/test_dropcontact.py
@@ -1,0 +1,143 @@
+"""Tests de l'enrichissement email Dropcontact (#21) — utils/dropcontact.py.
+
+Fallback PAYANT : on vérifie surtout la GARDE (éligibilité + opposition) qui décide
+quand on dépense, et l'appariement ordonné de la réponse. `soumettre`/`resultat`
+sont monkeypatchés — aucun appel réseau, aucun crédit consommé.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from utils import dropcontact as dc
+from utils.dropcontact import _eligibles, _email_de, _payload, enrichir_emails
+from models.prospect import Prospect
+
+CID = uuid.uuid4()
+
+
+def _p(nom_dirigeant="Jean Dupont", email=None, oppose=False, contactable=True, **o) -> Prospect:
+    """Prospect avec verdict d'opposition posé dans raw_data (comme le fait #19).
+    `contactable=True` -> oppose=False vérifié ; `contactable=False` -> non vérifié."""
+    p = Prospect(campagne_id=CID, nom_entreprise="ACME SAS",
+                 nom_dirigeant=nom_dirigeant, email=email, **o)
+    if contactable:
+        p.raw_data = {"opposition_commerciale": {"oppose": oppose}}
+    return p
+
+
+# --- Garde d'éligibilité ----------------------------------------------------
+def test_eligible_si_sans_email_avec_dirigeant_et_contactable():
+    assert len(_eligibles([_p()])) == 1
+
+
+def test_non_eligible_si_email_deja_present():
+    assert _eligibles([_p(email="a@b.fr")]) == []
+
+
+def test_non_eligible_si_pas_de_dirigeant():
+    assert _eligibles([_p(nom_dirigeant=None)]) == []
+
+
+def test_non_eligible_si_oppose():
+    # Garde légale : un prospect opposé ne doit jamais partir chez Dropcontact.
+    assert _eligibles([_p(oppose=True)]) == []
+
+
+def test_non_eligible_si_opposition_non_verifiee():
+    # Fermé par défaut : non vérifié -> non contactable -> non soumis.
+    assert _eligibles([_p(contactable=False)]) == []
+
+
+# --- Payload / parsing ------------------------------------------------------
+def test_payload_full_name_company_siren():
+    p = _p(siren="552081317")
+    item = _payload([p])[0]
+    assert item["full_name"] == "Jean Dupont"
+    assert item["company"] == "ACME SAS"
+    assert item["num_siren"] == "552081317"
+
+
+def test_email_de_liste_et_vide():
+    assert _email_de({"email": [{"email": "jean.dupont@acme.fr", "qualification": "ok"}]}) == "jean.dupont@acme.fr"
+    assert _email_de({"email": []}) is None
+    assert _email_de({}) is None
+
+
+# --- Orchestrateur (réseau mocké) -------------------------------------------
+def _mock_api(monkeypatch, data, request_id="rid-1"):
+    calls = {"soumis_payload": None}
+
+    async def _soumettre(payload, client, settings):
+        calls["soumis_payload"] = payload
+        return request_id
+
+    async def _resultat(rid, client, settings, poll_interval=5.0, max_attempts=24):
+        return data
+
+    monkeypatch.setattr(dc, "soumettre", _soumettre)
+    monkeypatch.setattr(dc, "resultat", _resultat)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_enrichir_pose_email_trouve(monkeypatch):
+    _mock_api(monkeypatch, [{"email": [{"email": "jean.dupont@acme.fr"}]}])
+    p = _p()
+    stats = await enrichir_emails([p], settings=_SettingsAvecCle())
+    assert p.email == "jean.dupont@acme.fr"
+    assert p.raw_data["dropcontact"]["retenu"] is True
+    assert stats == {"eligibles": 1, "soumis": 1, "emails": 1}
+
+
+@pytest.mark.asyncio
+async def test_appariement_ordonne(monkeypatch):
+    _mock_api(monkeypatch, [
+        {"email": [{"email": "a.un@acme.fr"}]},
+        {"email": []},  # 2e sans résultat
+    ])
+    p1 = _p(nom_dirigeant="A Un")
+    p2 = _p(nom_dirigeant="B Deux")
+    await enrichir_emails([p1, p2], settings=_SettingsAvecCle())
+    assert p1.email == "a.un@acme.fr"
+    assert p2.email is None
+
+
+@pytest.mark.asyncio
+async def test_opposes_pas_soumis(monkeypatch):
+    calls = _mock_api(monkeypatch, [{"email": [{"email": "x@acme.fr"}]}])
+    ok = _p(nom_dirigeant="OK Un")
+    oppose = _p(nom_dirigeant="Non Deux", oppose=True)
+    await enrichir_emails([ok, oppose], settings=_SettingsAvecCle())
+    # Seul le prospect contactable figure dans le payload soumis.
+    noms = [i["full_name"] for i in calls["soumis_payload"]]
+    assert noms == ["OK Un"]
+
+
+@pytest.mark.asyncio
+async def test_budget_plafonne_les_soumis(monkeypatch):
+    calls = _mock_api(monkeypatch, [{"email": []}])
+    ps = [_p(nom_dirigeant=f"D {i}") for i in range(5)]
+    stats = await enrichir_emails(ps, settings=_SettingsAvecCle(), budget=2)
+    assert stats["soumis"] == 2
+    assert len(calls["soumis_payload"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_sans_cle_api_ne_soumet_pas(monkeypatch):
+    calls = _mock_api(monkeypatch, [{"email": [{"email": "x@acme.fr"}]}])
+    p = _p()
+    stats = await enrichir_emails([p], settings=_SettingsSansCle())
+    assert stats == {"eligibles": 1, "soumis": 0, "emails": 0}
+    assert calls["soumis_payload"] is None  # jamais soumis
+    assert p.email is None
+
+
+# --- Doubles de settings ----------------------------------------------------
+class _SettingsAvecCle:
+    dropcontact_api_key = "test-token"
+
+
+class _SettingsSansCle:
+    dropcontact_api_key = ""

--- a/utils/dropcontact.py
+++ b/utils/dropcontact.py
@@ -1,11 +1,188 @@
-"""Enrichissement emails B2B via Dropcontact (source légale, règle #2).
+"""Enrichissement email B2B via Dropcontact (#21) — fallback PAYANT.
 
-Issue #11 — STUB. Implémentation détaillée portée par une issue dédiée.
-Dropcontact : 24€/mois/coût MVP — voir CLAUDE.md section coût.
+Dernier recours de la chaîne email, **après** la chaîne gratuite (OSM #69 +
+cascade #18). Dropcontact devine l'email professionnel (prénom.nom@entreprise) à
+partir du nom du dirigeant (#67) + la raison sociale + le SIREN — **sans besoin de
+site web** (contrairement à la spec d'origine de #21, corrigée ici).
+
+## Facturation « pay on success »
+
+Un crédit n'est débité que si un email vérifié est renvoyé ; les recherches
+infructueuses sont gratuites. Mesuré : **0 email sur 15 micro-entreprises**
+locales (garages/hôtels), **1/4 sur des PME B2B établies**. Donc à réserver aux
+ICP « PME établies » — inutile sur des micro-entreprises (cf. issue #21).
+
+## Garde légale AVANT dépense (non négociable)
+
+On n'interroge Dropcontact que pour les prospects **vérifiés non opposés**
+(`peut_etre_contacte()`, art. R123-232). Le nettoyage (#19) doit donc avoir tourné
+avant : envoyer un prospect opposé chez un enrichisseur tiers est exactement ce que
+le droit d'opposition interdit. Condition d'appel complète :
+
+    email IS None  ET  nom_dirigeant IS NOT None  ET  peut_etre_contacte(p)
+
+## API réelle (la spec #21 et ARCHITECTURE.md étaient fausses)
+
+- `POST https://api.dropcontact.com/v1/enrich/all` — corps `{"data": [...], "siren": true}`
+- Auth : header **`X-Access-Token`** (pas Bearer)
+- Polling : `GET /v1/enrich/all/{request_id}` jusqu'à `success: true`
+- La réponse conserve l'ORDRE des entrées.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Iterable
 
-async def enrichir_email(siret: str) -> dict | None:
-    """STUB — enrichit un SIRET en email B2B via Dropcontact. À implémenter."""
-    raise NotImplementedError("utils/dropcontact non implémenté — voir issue dédiée.")
+import httpx
+
+from config.settings import Settings, get_settings
+from models.prospect import Prospect, _clean_email
+from utils.opposition_commerciale import peut_etre_contacte
+
+logger = logging.getLogger(__name__)
+
+DROPCONTACT_URL = "https://api.dropcontact.com/v1/enrich/all"
+POLL_INTERVAL_S = 5.0
+MAX_ATTEMPTS = 24  # ~2 min à 5 s
+
+
+def _eligibles(prospects: Iterable[Prospect]) -> list[Prospect]:
+    """Prospects éligibles à l'appel Dropcontact : sans email, avec dirigeant, et
+    **vérifiés non opposés** (garde légale). Website non requis."""
+    return [
+        p for p in prospects
+        if p.email is None and p.nom_dirigeant and peut_etre_contacte(p)
+    ]
+
+
+def _payload(prospects: list[Prospect]) -> list[dict]:
+    """Entrées Dropcontact. `full_name` + `company` est le combo minimal viable ;
+    on ajoute SIREN/SIRET (toujours dispo via Sirene) pour fiabiliser le matching."""
+    items: list[dict] = []
+    for p in prospects:
+        item: dict = {"full_name": p.nom_dirigeant, "company": p.nom_entreprise}
+        if p.siren:
+            item["num_siren"] = p.siren
+        if p.siret:
+            item["siret"] = p.siret
+        if p.site_web:
+            item["website"] = p.site_web
+        items.append(item)
+    return items
+
+
+def _email_de(item: dict) -> str | None:
+    """Extrait l'email d'une entrée de réponse Dropcontact (`email` = liste
+    d'objets `{email, qualification}`)."""
+    emails = item.get("email") or []
+    if isinstance(emails, list) and emails:
+        return emails[0].get("email")
+    if isinstance(emails, str):  # tolérance si l'API renvoie une chaîne
+        return emails or None
+    return None
+
+
+async def soumettre(
+    data: list[dict], client: httpx.AsyncClient, settings: Settings
+) -> str | None:
+    """Soumet le lot, retourne le `request_id`. None si l'API échoue."""
+    try:
+        resp = await client.post(
+            DROPCONTACT_URL,
+            json={"data": data, "siren": True},
+            headers={"X-Access-Token": settings.dropcontact_api_key,
+                     "Content-Type": "application/json"},
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        return resp.json().get("request_id")
+    except Exception as exc:
+        logger.warning("Dropcontact soumission KO : %s", exc)
+        return None
+
+
+async def resultat(
+    request_id: str, client: httpx.AsyncClient, settings: Settings,
+    poll_interval: float = POLL_INTERVAL_S, max_attempts: int = MAX_ATTEMPTS,
+) -> list[dict]:
+    """Poll jusqu'à `success: true`. [] si timeout ou erreur (jamais bloquant)."""
+    url = f"{DROPCONTACT_URL}/{request_id}"
+    headers = {"X-Access-Token": settings.dropcontact_api_key}
+    for tentative in range(max_attempts):
+        try:
+            resp = await client.get(url, headers=headers, timeout=30.0)
+            resp.raise_for_status()
+            body = resp.json()
+        except Exception as exc:
+            logger.warning("Dropcontact polling KO : %s", exc)
+            return []
+        if body.get("success"):
+            return body.get("data", []) or []
+        if tentative < max_attempts - 1:
+            await asyncio.sleep(poll_interval)
+    logger.warning("Dropcontact : résultat non prêt après %d tentatives", max_attempts)
+    return []
+
+
+async def enrichir_emails(
+    prospects: Iterable[Prospect],
+    client: httpx.AsyncClient | None = None,
+    settings: Settings | None = None,
+    budget: int | None = None,
+    poll_interval: float = POLL_INTERVAL_S,
+    max_attempts: int = MAX_ATTEMPTS,
+) -> dict[str, int]:
+    """Complète l'email des prospects éligibles via Dropcontact (fallback payant).
+
+    `budget` plafonne le nombre de prospects soumis (pay on success : les échecs ne
+    coûtent rien, mais on borne quand même la dépense potentielle). Retourne des
+    compteurs {eligibles, soumis, emails} pour le log / les métriques (#23).
+    """
+    settings = settings or get_settings()
+    prospects = list(prospects)
+    stats = {"eligibles": 0, "soumis": 0, "emails": 0}
+
+    elig = _eligibles(prospects)
+    stats["eligibles"] = len(elig)
+    if not elig:
+        return stats
+    if not settings.dropcontact_api_key:
+        logger.warning("dropcontact_api_key absente — enrichissement email ignoré")
+        return stats
+    if budget is not None:
+        elig = elig[:budget]
+    stats["soumis"] = len(elig)
+
+    ferme_client = client is None
+    client = client or httpx.AsyncClient()
+    try:
+        request_id = await soumettre(_payload(elig), client, settings)
+        if not request_id:
+            return stats
+        data = await resultat(request_id, client, settings, poll_interval, max_attempts)
+        # La réponse conserve l'ordre des entrées -> appariement par position.
+        for prospect, item in zip(elig, data):
+            brut = _email_de(item)
+            email = _clean_email(brut) if brut else None
+            if prospect.email is None and email:
+                prospect.email = email
+                stats["emails"] += 1
+            prospect.raw_data = {
+                **(prospect.raw_data or {}),
+                "dropcontact": {
+                    "email": brut,
+                    "retenu": bool(email) and prospect.email == email,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                },
+            }
+    finally:
+        if ferme_client:
+            await client.aclose()
+
+    logger.info(
+        "dropcontact : %d éligible(s), %d soumis, %d email(s) trouvé(s)",
+        stats["eligibles"], stats["soumis"], stats["emails"],
+    )
+    return stats


### PR DESCRIPTION
Closes #21 (code + tests). Base `main`, pas d'empilement.

Remplace le stub. **Dernier recours** de la chaîne email — après la chaîne gratuite (OSM #69 + cascade #18). Facturation **pay on success** : les échecs ne coûtent rien.

## Corrections de spec (mesurées, cf. #21)
- **API réelle** : `POST /v1/enrich/all` + header `X-Access-Token` + polling `GET /v1/enrich/all/{id}`. La spec disait `POST /batch` — faux.
- **Condition d'appel** : `email IS None ET nom_dirigeant ET peut_etre_contacte(p)`. `site_web IS NOT None` **retiré** (jamais vrai — 0 % de sites obtenus — et inutile, Dropcontact matche sans domaine). `nom_dirigeant` est désormais peuplé par #67.

## Garde légale (non négociable)
On ne soumet **que** les prospects **vérifiés non opposés** (`peut_etre_contacte()`, art. R123-232) : le nettoyage #19 pose le verdict avant. Un prospect opposé — ou non vérifié (fermé par défaut) — n'est **jamais** envoyé chez l'enrichisseur tiers.

## Min-argent
- Pay on success + `budget` qui plafonne le nombre de soumis.
- N'est pertinent que sur des **PME B2B établies** (mesuré 1/4) — **0/15 sur micro-entreprises** locales. À n'activer que si l'ICP le justifie.
- Compteurs `{eligibles, soumis, emails}` exposés pour le suivi de coût (#23).

## Tests
12 tests, `soumettre`/`resultat` monkeypatchés (**aucun crédit**) : garde d'éligibilité, opposés/non-vérifiés jamais soumis, appariement ordonné de la réponse, budget, absence de clé. **177 pass, 2 skip**.

## Hors périmètre (suivi)
Câblage cascade/pré-passe (#18/#28) et mesure live (ops) — la logique et la garde sont prêtes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

