### PR TITLE
feat(#24): couche règles du scoring — _score_regles pur + tests

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -1,18 +1,125 @@
-"""Node LangChain — scoring hybride 3 couches (règles + Claude + embeddings).
+"""Agent de scoring hybride 3 couches (règles + Claude + embeddings).
 
-Issue #11 — STUB. Implémentation détaillée portée par les issues de scoring
-(cf. docs/SCORING.md, docs/ISSUES.md).
+Issue #11 — squelette. **Couche 1 (règles métier, #24) implémentée ci-dessous.**
+Les couches 2 (LLM Claude, #25) et 3 (embeddings, #26), l'agrégation/persistance
+(#27) et l'assemblage dans le graphe (`scoring_node`, #28) suivent.
 
-Rappels (CLAUDE.md règles #5, #6) :
-- Embeddings locaux sur CPU via Ollama + nomic-embed-text (utils/embeddings.py).
-- LLM scorer en cloud : Claude API uniquement (modèle configurable dans
-  config/settings.py, jamais codé en dur dans les prompts).
-- Les prompts sont rendus dynamiquement depuis l'ICP du client
-  (prompts/scorer_system.txt.j2, prompts/scorer_user.txt.j2).
+Rappels (CLAUDE.md règles #3/#4/#5/#6) :
+- **Aucune valeur métier codée en dur** : NAF, effectif, mots-clés viennent tous de
+  `CriteresCiblage` (l'ICP du client), jamais de constantes Python.
+- Un prospect qui matche une exclusion ICP (`mots_cles_negatifs`) → score = 0 (règle #4).
+
+Barème détaillé et échelles : `docs/SCORING.md` (couche 1).
 """
 from __future__ import annotations
 
+from datetime import date
 
+# ⟳ RÉUTILISÉ, jamais redéfini : l'exclusion par mot entier (garde légale/business,
+# règle #4) a une seule source de vérité, partagée avec le nettoyage (#19).
+from agents.nettoyage_agent import _matche_exclusion
+from models.criteres import CriteresCiblage
+from models.prospect import Prospect
+
+
+# --- Couche 1 : règles métier (#24) -----------------------------------------
+# Pures, déterministes, entièrement paramétrées par l'ICP client. Aucune I/O,
+# aucun appel réseau : 100 % testables hors ligne.
+
+def _score_effectif(
+    effectif_estime: int | None, effectif_min: int, effectif_max: int
+) -> int:
+    """Max 20. Pleins points si l'effectif estimé est dans la fourchette ICP,
+    dégressif au-delà. Effectif inconnu (`None`) → 0 : on ne devine pas une
+    donnée absente (cohérent avec le filtre effectif du nettoyage, #19)."""
+    if effectif_estime is None:
+        return 0
+    if effectif_min <= effectif_estime <= effectif_max:
+        return 20
+    ecart = min(abs(effectif_estime - effectif_min), abs(effectif_estime - effectif_max))
+    return 10 if ecart <= 3 else 5
+
+
+def _score_anciennete(date_creation: date, anciennete_min_ans: int) -> int:
+    """Max 15. Barème relatif au seuil minimal d'ancienneté défini par le client.
+    Sous le seuil → 0 ; puis paliers à +2 ans et +7 ans au-dessus du seuil."""
+    anciennete_ans = (date.today() - date_creation).days / 365.25
+    if anciennete_ans < anciennete_min_ans:
+        return 0
+    if anciennete_ans >= anciennete_min_ans + 7:
+        return 15
+    if anciennete_ans >= anciennete_min_ans + 2:
+        return 10
+    return 5
+
+
+def _score_mots_cles_positifs(prospect: Prospect, mots_cles: list[str] | None) -> int:
+    """Max 10. +5 par mot-clé positif de l'ICP présent dans les données du
+    prospect (nom + libellé NAF + notes d'enrichissement), plafonné à 10,
+    insensible à la casse."""
+    if not mots_cles:
+        return 0
+    texte = (
+        f"{prospect.nom_entreprise} "
+        f"{prospect.libelle_naf or ''} "
+        f"{prospect.notes or ''}"
+    ).lower()
+    hits = sum(1 for mot in mots_cles if mot.lower() in texte)
+    return min(hits * 5, 10)
+
+
+def _score_regles(prospect: Prospect, criteres: CriteresCiblage) -> int:
+    """Score règles 0-100, déterministe, entièrement paramétré par l'ICP client.
+
+    Le téléphone et l'email sont déjà normalisés/nettoyés à la construction du
+    `Prospect` (validators E.164 et `_clean_email` — politique email #65 appliquée
+    en amont) : on crédite simplement leur présence, sans re-filtrer ici. Un
+    prospect qui matche une exclusion ICP est forcé à 0 (règle #4). Voir
+    `docs/SCORING.md` (couche 1) pour le détail des sous-scores.
+    """
+    score = 0
+
+    # CONTACT (max 35)
+    if prospect.telephone:
+        score += 25
+    if prospect.email:
+        score += 10
+
+    # EFFECTIF (max 20)
+    score += _score_effectif(
+        prospect.effectif_estime, criteres.effectif_min, criteres.effectif_max
+    )
+
+    # ANCIENNETÉ (max 15)
+    if prospect.date_creation:
+        score += _score_anciennete(prospect.date_creation, criteres.anciennete_min_ans)
+
+    # PRÉSENCE DIGITALE (max 10)
+    if prospect.site_web:
+        score += 8
+    if prospect.notes and "avis google" in prospect.notes.lower():
+        score += 2
+
+    # GÉOGRAPHIE (max 10) — bonus si dans les départements prioritaires de l'ICP
+    if prospect.departement in (criteres.departements or []):
+        score += 10
+
+    # MOTS-CLÉS POSITIFS (max 10)
+    score += _score_mots_cles_positifs(prospect, criteres.mots_cles_positifs)
+
+    # PÉNALITÉS
+    if _matche_exclusion(prospect, criteres.mots_cles_negatifs):
+        return 0  # exclusion ICP (règle #4) — prime sur tout le reste
+    if not prospect.telephone and not prospect.email:
+        score -= 20
+    if criteres.codes_naf and prospect.code_naf not in criteres.codes_naf:
+        score -= 30
+
+    return max(0, min(100, score))
+
+
+# --- Node d'assemblage (#28) — stub -----------------------------------------
 async def scoring_node(state: dict) -> dict:
-    """STUB — node de scoring hybride. À implémenter (issues dédiées)."""
-    raise NotImplementedError("scoring_agent non implémenté — voir issue dédiée.")
+    """STUB — node de scoring hybride. Couches 2/3 + agrégation + câblage à venir
+    (#25, #26, #27, #28). La couche règles ci-dessus est prête et testée (#24)."""
+    raise NotImplementedError("scoring_node non assemblé — voir #28.")

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,26 +1,226 @@
-"""Tests du scoring hybride (agents/scoring_agent.py + docs/SCORING.md).
+"""Tests de la couche règles du scoring (#24) — purs, déterministes, hors ligne.
 
-Issue #11 — STUB. Implémentation détaillée portée par les issues de scoring.
-Couvrira à terme : 20 cas + mock Claude (score règles, score LLM, score
-embedding, combinaison pondérée, exclusion mots-clés négatifs → score 0).
+Couvre les sous-scorers (`_score_effectif`, `_score_anciennete`,
+`_score_mots_cles_positifs`) et le barème intégré `_score_regles` : crédit
+contact/effectif/ancienneté/présence/géo/mots-clés, pénalités (sans contact,
+NAF hors ICP), exclusion ICP forcée à 0 (règle #4), et le plafonnement 0-100.
+Toutes les valeurs métier viennent de `CriteresCiblage` (règle #3). Aucun réseau.
 """
 from __future__ import annotations
 
 import asyncio
 import inspect
+import uuid
+from datetime import date, timedelta
 
 import pytest
 
+from agents.scoring_agent import (
+    _score_anciennete,
+    _score_effectif,
+    _score_mots_cles_positifs,
+    _score_regles,
+)
+from models.criteres import CriteresCiblage
+from models.prospect import Prospect
 
+CID = uuid.uuid4()
+
+# Valeurs qui PASSENT les validators du Prospect (sinon mises à None à la construction).
+TEL_OK = "0123456789"                      # ligne fixe FR -> +33123456789
+EMAIL_OK = "contact@garage-durand.fr"      # générique commerciale -> conservée (#65)
+
+
+def _p(nom="Garage Durand", **o) -> Prospect:
+    return Prospect(campagne_id=CID, nom_entreprise=nom, **o)
+
+
+def _criteres(**o) -> CriteresCiblage:
+    base = dict(nom="ICP test")
+    base.update(o)
+    return CriteresCiblage(**base)
+
+
+def _il_y_a(annees: float) -> date:
+    """Date de création située `annees` en arrière (via 365.25 j/an, comme le barème)."""
+    return date.today() - timedelta(days=round(annees * 365.25))
+
+
+# --- _score_effectif (max 20) -----------------------------------------------
+@pytest.mark.parametrize(
+    "effectif, attendu",
+    [
+        (8, 20),     # dans la fourchette
+        (2, 20),     # borne basse
+        (15, 20),    # borne haute
+        (16, 10),    # ecart 1 <= 3
+        (18, 10),    # ecart 3 <= 3
+        (19, 5),     # ecart 4 > 3
+        (0, 10),     # ecart min(|0-2|,|0-15|)=2 <= 3
+        (100, 5),    # loin au-dessus de la fourchette
+    ],
+)
+def test_score_effectif(effectif, attendu):
+    assert _score_effectif(effectif, 2, 15) == attendu
+
+
+def test_score_effectif_inconnu_ne_devine_pas():
+    assert _score_effectif(None, 2, 15) == 0
+
+
+# --- _score_anciennete (max 15), seuil ICP = 3 ans --------------------------
+@pytest.mark.parametrize(
+    "annees_ago, attendu",
+    [
+        (11, 15),    # >= min+7 (10)
+        (6, 10),     # >= min+2 (5), < 10
+        (3.5, 5),    # >= min (3), < 5
+        (2, 0),      # < min
+    ],
+)
+def test_score_anciennete(annees_ago, attendu):
+    assert _score_anciennete(_il_y_a(annees_ago), anciennete_min_ans=3) == attendu
+
+
+# --- _score_mots_cles_positifs (max 10) -------------------------------------
+def test_mots_cles_none_ou_vide():
+    p = _p(libelle_naf="Carrosserie")
+    assert _score_mots_cles_positifs(p, None) == 0
+    assert _score_mots_cles_positifs(p, []) == 0
+
+
+def test_mots_cles_un_hit():
+    p = _p(libelle_naf="Entretien et réparation, carrosserie")
+    assert _score_mots_cles_positifs(p, ["carrosserie"]) == 5
+
+
+def test_mots_cles_deux_hits():
+    p = _p(libelle_naf="Carrosserie et peinture automobile")
+    assert _score_mots_cles_positifs(p, ["carrosserie", "peinture"]) == 10
+
+
+def test_mots_cles_plafonne_a_10():
+    p = _p(nom="Carrosserie Peinture Mécanique Durand", libelle_naf="carrosserie peinture")
+    assert _score_mots_cles_positifs(p, ["carrosserie", "peinture", "mécanique"]) == 10
+
+
+def test_mots_cles_insensible_casse():
+    p = _p(libelle_naf="CARROSSERIE")
+    assert _score_mots_cles_positifs(p, ["carrosserie"]) == 5
+
+
+def test_mots_cles_cherche_dans_notes():
+    p = _p(libelle_naf="Réparation", notes="Signalé comme spécialiste peinture")
+    assert _score_mots_cles_positifs(p, ["peinture"]) == 5
+
+
+# --- _score_regles : barème intégré -----------------------------------------
+def test_regles_prospect_ideal():
+    """Contact + effectif + ancienneté + site + avis + géo + mot-clé = 95, sans pénalité."""
+    crit = _criteres(
+        codes_naf=["4520Z"], departements=["75"], effectif_min=2, effectif_max=15,
+        anciennete_min_ans=3, mots_cles_positifs=["carrosserie"],
+    )
+    p = _p(
+        code_naf="4520Z", departement="75", effectif_estime=8,
+        telephone=TEL_OK, email=EMAIL_OK, site_web="https://garage-durand.fr",
+        date_creation=_il_y_a(20), libelle_naf="Réparation, carrosserie",
+        notes="Bien noté sur avis google",
+    )
+    # 25 + 10 + 20 + 15 + 8 + 2 + 10 + 5 = 95
+    assert _score_regles(p, crit) == 95
+
+
+def test_regles_exclusion_force_a_zero():
+    """Une exclusion ICP (mot entier) prime sur un prospect par ailleurs excellent."""
+    crit = _criteres(
+        departements=["75"], effectif_min=2, effectif_max=15,
+        mots_cles_negatifs=["durand"],
+    )
+    p = _p(
+        nom="Garage Durand", departement="75", effectif_estime=8,
+        telephone=TEL_OK, email=EMAIL_OK, site_web="https://x.fr",
+    )
+    assert _score_regles(p, crit) == 0
+
+
+def test_regles_exclusion_mot_entier_pas_sous_chaine():
+    """« durand » n'exclut pas « Durandal » (mot entier, réutilise nettoyage #19)."""
+    crit = _criteres(effectif_min=2, effectif_max=15, mots_cles_negatifs=["durand"])
+    p = _p(nom="Garage Durandal", effectif_estime=8, telephone=TEL_OK)
+    assert _score_regles(p, crit) == 45  # 25 (tel) + 20 (effectif), pas d'exclusion
+
+
+def test_regles_penalite_sans_contact():
+    """Sans téléphone NI email : -20. Le contact vaut 35 + évite la pénalité."""
+    crit = _criteres(effectif_min=2, effectif_max=15, departements=["75"])
+    avec = _p(departement="75", effectif_estime=8, telephone=TEL_OK, email=EMAIL_OK)
+    sans = _p(departement="75", effectif_estime=8)
+    assert _score_regles(avec, crit) == 65   # 35 + 20 + 10
+    assert _score_regles(sans, crit) == 10   # 20 + 10 - 20
+
+
+def test_regles_credit_email_isole():
+    """Téléphone présent dans les deux : l'email seul vaut +10 (pas de pénalité contact)."""
+    crit = _criteres(effectif_min=2, effectif_max=15)
+    avec = _p(effectif_estime=8, telephone=TEL_OK, email=EMAIL_OK)
+    sans = _p(effectif_estime=8, telephone=TEL_OK)
+    assert _score_regles(avec, crit) == 55   # 25 + 10 + 20
+    assert _score_regles(sans, crit) == 45   # 25 + 20
+
+
+def test_regles_penalite_naf_hors_icp():
+    """NAF hors des codes ICP : -30. NAF dans l'ICP : pas de pénalité."""
+    crit = _criteres(codes_naf=["1234Z"], effectif_min=2, effectif_max=15)
+    dedans = _p(code_naf="1234Z", effectif_estime=8, telephone=TEL_OK, email=EMAIL_OK)
+    dehors = _p(code_naf="9999Z", effectif_estime=8, telephone=TEL_OK, email=EMAIL_OK)
+    assert _score_regles(dedans, crit) == 55   # 35 + 20
+    assert _score_regles(dehors, crit) == 25   # 35 + 20 - 30
+
+
+def test_regles_codes_naf_vides_pas_de_penalite():
+    """ICP sans codes_naf : aucune pénalité NAF, quel que soit le code du prospect."""
+    crit = _criteres(codes_naf=[], effectif_min=2, effectif_max=15)
+    p = _p(code_naf="9999Z", effectif_estime=8, telephone=TEL_OK)
+    assert _score_regles(p, crit) == 45   # 25 + 20, pas de -30
+
+
+def test_regles_plancher_a_zero():
+    """Cumul de pénalités : jamais en dessous de 0 (clamp)."""
+    crit = _criteres(codes_naf=["1234Z"], effectif_min=2, effectif_max=15)
+    p = _p(code_naf="9999Z")  # ni contact, ni effectif connu, NAF hors ICP
+    assert _score_regles(p, crit) == 0   # max(0, 0 - 20 - 30)
+
+
+def test_regles_bonus_geo_uniquement_si_departement_prioritaire():
+    """Le bonus géo (+10) ne s'applique que dans les départements de l'ICP."""
+    crit = _criteres(effectif_min=2, effectif_max=15, departements=["75", "92"])
+    dedans = _p(departement="92", effectif_estime=8, telephone=TEL_OK)
+    dehors = _p(departement="13", effectif_estime=8, telephone=TEL_OK)
+    assert _score_regles(dedans, crit) == 55   # 25 + 20 + 10
+    assert _score_regles(dehors, crit) == 45   # 25 + 20
+
+
+def test_regles_effectif_estime_pas_le_libelle():
+    """Le barème lit effectif_estime (int), pas le libellé texte effectif."""
+    crit = _criteres(effectif_min=2, effectif_max=15)
+    # Libellé renseigné mais effectif_estime absent -> 0 pt d'effectif (on ne devine pas).
+    p = _p(effectif="20 à 49 salariés", effectif_estime=None, telephone=TEL_OK)
+    assert _score_regles(p, crit) == 25   # 25 (tel) + 0 (effectif inconnu)
+
+
+# --- Node d'assemblage (#28) — reste un stub tant que le graphe n'est pas câblé ----
+# Conservés depuis #11 : la couche règles est prête (#24) mais `scoring_node` (câblage
+# des 3 couches + agrégation) n'est assemblé qu'en #28.
 def test_scoring_node_is_async_coroutine() -> None:
-    """STUB #11 — scoring_node est bien une coroutine async (règle #8)."""
+    """`scoring_node` est bien une coroutine async (règle #8)."""
     from agents.scoring_agent import scoring_node
 
     assert inspect.iscoroutinefunction(scoring_node)
 
 
 def test_scoring_node_stub_raises_not_implemented() -> None:
-    """STUB #11 — le node lève NotImplementedError (pas une erreur d'import)."""
+    """Le node lève NotImplementedError tant que #28 ne l'a pas assemblé."""
     from agents.scoring_agent import scoring_node
 
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
**Sprint 3, PR 1/4 du cœur scoring.** Implémente la **couche 1 (règles métier)** du scoring hybride — pure, déterministe, entièrement pilotée par l'ICP client (règle #3), 100 % testable hors ligne. `Closes #24`.

### Contenu
- `_score_regles(prospect, criteres) -> int` : contact (35) / effectif (20) / ancienneté (15) / présence digitale (10) / géo (10) / mots-clés positifs (10), pénalités (sans contact −20, NAF hors ICP −30), plafonné 0-100.
- **Exclusion ICP** (`mots_cles_negatifs`) → score **0**, via **`_matche_exclusion` réutilisée** depuis `nettoyage_agent` (règle #4, une seule source de vérité, matching mot entier — jamais redéfinie).
- Lit **`effectif_estime`** (int) ; crédite la simple présence de l'email (déjà nettoyé par `_clean_email`, politique #65) — **pas de re-blacklist**.
- Sous-scorers purs `_score_effectif` / `_score_anciennete` / `_score_mots_cles_positifs`.
- `scoring_node` reste un **stub** (assemblage en #28).

### Tests — `tests/test_scoring.py`
+29 cas : sous-scorers paramétrés (effectif/ancienneté/mots-clés), barème intégré (prospect idéal = 95, crédit email isolé, bonus géo, effectif_estime vs libellé), exclusion (mot entier, pas sous-chaîne), pénalités (sans contact, NAF hors ICP), plafond à 0. **Les 2 tests stub #11 sont conservés** (le node reste un stub). Aucun réseau.

`pytest -m "not integration"` : **244 passed, 3 deselected**.

### Notes
- Conforme à `docs/SCORING.md` **réconcilié dans #90** (email #65, `effectif_estime`, `_matche_exclusion`, `prospect.id` inexistant). #90 et cette PR touchent des fichiers **disjoints** → fusionnables dans n'importe quel ordre.
- Base `main`, pas d'empilement. Prochaine PR : **#26 embeddings** (`get_embedding` + cosinus Python pur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)