### PR TITLE
feat(#26): couche embeddings du scoring — _score_embedding (cosinus Python pur)

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -1,18 +1,20 @@
 """Agent de scoring hybride 3 couches (règles + Claude + embeddings).
 
-Issue #11 — squelette. **Couche 1 (règles métier, #24) implémentée ci-dessous.**
-Les couches 2 (LLM Claude, #25) et 3 (embeddings, #26), l'agrégation/persistance
-(#27) et l'assemblage dans le graphe (`scoring_node`, #28) suivent.
+Issue #11 — squelette. **Couche 1 (règles métier, #24) et couche 3 (embeddings,
+#26) implémentées ci-dessous.** La couche 2 (LLM Claude, #25), l'agrégation/
+persistance (#27) et l'assemblage dans le graphe (`scoring_node`, #28) suivent.
 
 Rappels (CLAUDE.md règles #3/#4/#5/#6) :
 - **Aucune valeur métier codée en dur** : NAF, effectif, mots-clés viennent tous de
   `CriteresCiblage` (l'ICP du client), jamais de constantes Python.
 - Un prospect qui matche une exclusion ICP (`mots_cles_negatifs`) → score = 0 (règle #4).
+- Embeddings **locaux sur CPU** via Ollama (règle #5) — aucune API d'embedding tierce.
 
-Barème détaillé et échelles : `docs/SCORING.md` (couche 1).
+Barème détaillé et échelles : `docs/SCORING.md`.
 """
 from __future__ import annotations
 
+import math
 from datetime import date
 
 # ⟳ RÉUTILISÉ, jamais redéfini : l'exclusion par mot entier (garde légale/business,
@@ -20,6 +22,8 @@ from datetime import date
 from agents.nettoyage_agent import _matche_exclusion
 from models.criteres import CriteresCiblage
 from models.prospect import Prospect
+from utils.db import upsert_prospect_embedding
+from utils.embeddings import get_embedding
 
 
 # --- Couche 1 : règles métier (#24) -----------------------------------------
@@ -116,6 +120,65 @@ def _score_regles(prospect: Prospect, criteres: CriteresCiblage) -> int:
         score -= 30
 
     return max(0, min(100, score))
+
+
+# --- Couche 3 : similarité embeddings ICP (#26) -----------------------------
+# Cosinus en Python pur (pas de numpy). Vecteur du prospect généré localement sur
+# CPU via Ollama (règle #5). Renvoie un COSINUS 0-1 ; le ×100 n'a lieu qu'à
+# l'agrégation (#27), cohérent avec models.score.ScoreResult.score_embedding
+# (Field ge=0.0, le=1.0).
+
+def _cosinus(a: list[float], b: list[float]) -> float:
+    """Similarité cosinus entre deux vecteurs, en Python pur (pas de numpy).
+    Renvoie 0.0 si l'un des vecteurs est nul (norme 0) — pas de division par zéro."""
+    produit = sum(x * y for x, y in zip(a, b))
+    norme_a = math.sqrt(sum(x * x for x in a))
+    norme_b = math.sqrt(sum(y * y for y in b))
+    if norme_a == 0.0 or norme_b == 0.0:
+        return 0.0
+    return produit / (norme_a * norme_b)
+
+
+async def _score_embedding(
+    prospect: Prospect,
+    icp_embedding: list[float] | None,
+    prospect_id: str | None = None,
+) -> float:
+    """Similarité cosinus 0-1 entre le prospect et l'ICP du client.
+
+    `icp_embedding` vient de `EtatAgent["icp_embedding"]` (chargé par init_campagne
+    #16 via `get_icp_embedding`). Absent (ICP non initialisé, #12) → couche neutre
+    (`0.0`), on ne bloque pas. Le vecteur du prospect est généré localement (Ollama
+    CPU, règle #5) puis, si un `prospect_id` (UUID BDD retourné par `upsert_prospect`)
+    est fourni, persisté dans Qdrant. Retourne le cosinus borné à [0, 1] ; le ×100
+    est fait à l'agrégation (#27).
+    """
+    if not icp_embedding:
+        return 0.0
+
+    texte = (
+        f"{prospect.nom_entreprise}, {prospect.libelle_naf or ''}, "
+        f"{prospect.effectif_estime or '?'} salariés, "
+        f"{prospect.ville or ''} ({prospect.departement or ''}), "
+        f"créé {prospect.date_creation or '?'}, "
+        f"{'site web présent' if prospect.site_web else 'pas de site web'}"
+    ).strip()
+
+    vecteur = await get_embedding(texte)
+    cosinus = max(0.0, _cosinus(vecteur, icp_embedding))
+
+    if prospect_id:
+        await upsert_prospect_embedding(
+            prospect_id=prospect_id,
+            embedding=vecteur,
+            payload={
+                "campagne_id": str(prospect.campagne_id),
+                "code_naf": prospect.code_naf,
+                "departement": prospect.departement,
+                "nom_entreprise": prospect.nom_entreprise,
+            },
+        )
+    return cosinus
 
 
 # --- Node d'assemblage (#28) — stub -----------------------------------------

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,23 +1,28 @@
-"""Tests de la couche règles du scoring (#24) — purs, déterministes, hors ligne.
+"""Tests des couches de scoring — purs / mockés, déterministes, hors ligne.
 
-Couvre les sous-scorers (`_score_effectif`, `_score_anciennete`,
-`_score_mots_cles_positifs`) et le barème intégré `_score_regles` : crédit
-contact/effectif/ancienneté/présence/géo/mots-clés, pénalités (sans contact,
-NAF hors ICP), exclusion ICP forcée à 0 (règle #4), et le plafonnement 0-100.
-Toutes les valeurs métier viennent de `CriteresCiblage` (règle #3). Aucun réseau.
+Couche règles (#24) : sous-scorers (`_score_effectif`, `_score_anciennete`,
+`_score_mots_cles_positifs`) + barème intégré `_score_regles` (contact, effectif,
+ancienneté, présence, géo, mots-clés, pénalités, exclusion #4, plafond 0-100).
+Couche embeddings (#26) : `_cosinus` (Python pur) + `_score_embedding` (Ollama et
+Qdrant mockés — aucun réseau ; cosinus borné 0-1, ICP absent → 0.0, upsert
+conditionnel au `prospect_id`). Valeurs métier depuis `CriteresCiblage` (règle #3).
 """
 from __future__ import annotations
 
 import asyncio
 import inspect
+import math
 import uuid
 from datetime import date, timedelta
 
 import pytest
 
+from agents import scoring_agent as sa   # pour monkeypatcher get_embedding / upsert
 from agents.scoring_agent import (
+    _cosinus,
     _score_anciennete,
     _score_effectif,
+    _score_embedding,
     _score_mots_cles_positifs,
     _score_regles,
 )
@@ -225,3 +230,118 @@ def test_scoring_node_stub_raises_not_implemented() -> None:
 
     with pytest.raises(NotImplementedError):
         asyncio.run(scoring_node({"prospects": []}))
+
+
+# --- Couche 3 : cosinus pur (#26) -------------------------------------------
+def test_cosinus_vecteurs_identiques():
+    assert _cosinus([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == pytest.approx(1.0)
+
+
+def test_cosinus_orthogonaux():
+    assert _cosinus([1.0, 0.0], [0.0, 1.0]) == 0.0
+
+
+def test_cosinus_opposes():
+    assert _cosinus([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+
+
+def test_cosinus_vecteur_nul_pas_de_division_par_zero():
+    assert _cosinus([0.0, 0.0, 0.0], [1.0, 2.0, 3.0]) == 0.0
+
+
+def test_cosinus_valeur_connue():
+    # angle 45° entre [1,1] et [1,0] -> cos = 1/sqrt(2)
+    assert _cosinus([1.0, 1.0], [1.0, 0.0]) == pytest.approx(1 / math.sqrt(2))
+
+
+# --- Couche 3 : _score_embedding (Ollama + Qdrant mockés) -------------------
+def test_score_embedding_icp_absent_court_circuite(monkeypatch):
+    """ICP non initialisé (None ou vide) → 0.0 sans appeler Ollama."""
+    appels = []
+
+    async def _fake_get(text):
+        appels.append(text)
+        return [1.0] * 4
+
+    monkeypatch.setattr(sa, "get_embedding", _fake_get)
+    assert asyncio.run(_score_embedding(_p(), None)) == 0.0
+    assert asyncio.run(_score_embedding(_p(), [])) == 0.0
+    assert appels == []   # aucun appel embedding (court-circuit)
+
+
+def test_score_embedding_retourne_cosinus_borne(monkeypatch):
+    """Cosinus 0-1 renvoyé (ici 1/sqrt(2) entre [1,1] et [1,0])."""
+    async def _fake_get(text):
+        return [1.0, 1.0]
+
+    monkeypatch.setattr(sa, "get_embedding", _fake_get)
+    assert asyncio.run(_score_embedding(_p(), [1.0, 0.0])) == pytest.approx(1 / math.sqrt(2))
+
+
+def test_score_embedding_cosinus_negatif_clampe_a_zero(monkeypatch):
+    """Un cosinus négatif est ramené à 0.0 (échelle [0, 1])."""
+    async def _fake_get(text):
+        return [-1.0, 0.0]
+
+    monkeypatch.setattr(sa, "get_embedding", _fake_get)
+    assert asyncio.run(_score_embedding(_p(), [1.0, 0.0])) == 0.0
+
+
+def test_score_embedding_upsert_avec_id_et_payload(monkeypatch):
+    """Avec un prospect_id : persistance Qdrant appelée avec le vecteur + payload indexable."""
+    recu = {}
+
+    async def _fake_get(text):
+        return [0.5, 0.5, 0.5, 0.5]
+
+    async def _fake_upsert(prospect_id, embedding, payload):
+        recu.update(id=prospect_id, embedding=embedding, payload=payload)
+
+    monkeypatch.setattr(sa, "get_embedding", _fake_get)
+    monkeypatch.setattr(sa, "upsert_prospect_embedding", _fake_upsert)
+
+    p = _p(nom="Garage Martin", code_naf="4520Z", departement="75")
+    asyncio.run(_score_embedding(p, [0.5, 0.5, 0.5, 0.5], prospect_id="uuid-bdd-123"))
+
+    assert recu["id"] == "uuid-bdd-123"
+    assert recu["embedding"] == [0.5, 0.5, 0.5, 0.5]
+    assert recu["payload"] == {
+        "campagne_id": str(CID),
+        "code_naf": "4520Z",
+        "departement": "75",
+        "nom_entreprise": "Garage Martin",
+    }
+
+
+def test_score_embedding_pas_d_upsert_sans_id(monkeypatch):
+    """Sans prospect_id : on calcule le cosinus mais on n'écrit rien dans Qdrant."""
+    a_ecrit = []
+
+    async def _fake_get(text):
+        return [1.0, 0.0]
+
+    async def _fake_upsert(prospect_id, embedding, payload):
+        a_ecrit.append(prospect_id)
+
+    monkeypatch.setattr(sa, "get_embedding", _fake_get)
+    monkeypatch.setattr(sa, "upsert_prospect_embedding", _fake_upsert)
+
+    asyncio.run(_score_embedding(_p(), [1.0, 0.0]))   # prospect_id=None
+    assert a_ecrit == []
+
+
+def test_score_embedding_texte_reprend_les_champs(monkeypatch):
+    """Le texte encodé reprend les champs discriminants du prospect."""
+    vu = {}
+
+    async def _fake_get(text):
+        vu["text"] = text
+        return [1.0, 0.0]
+
+    monkeypatch.setattr(sa, "get_embedding", _fake_get)
+    p = _p(nom="Garage Martin", libelle_naf="Réparation auto",
+           effectif_estime=8, ville="Paris", departement="75")
+    asyncio.run(_score_embedding(p, [1.0, 0.0]))
+
+    for attendu in ("Garage Martin", "Réparation auto", "Paris", "75", "8"):
+        assert attendu in vu["text"]


### PR DESCRIPTION
**Sprint 3, PR 2/4 du cœur scoring.** Implémente la **couche 3 (similarité embeddings ICP)** — vecteur local Ollama + cosinus Python pur. Branchée sur `main` **après fusion de #90+#91** (base propre, pas d'empilement). `Closes #26`.

### Contenu (`agents/scoring_agent.py`)
- **`_cosinus(a, b)`** — similarité cosinus en **Python pur** (pas de numpy, règle « pas de dépendance lourde ») ; garde division-par-zéro → `0.0`.
- **`_score_embedding(prospect, icp_embedding, prospect_id=None)`** — texte prospect → `get_embedding` (**Ollama CPU**, règle #5) → cosinus borné **[0, 1]** avec l'ICP. `upsert_prospect_embedding` (Qdrant) **conditionnel au `prospect_id`** (UUID BDD retourné par `upsert_prospect` — le modèle Pydantic n'a pas d'`id`). ICP absent (#12) → couche neutre `0.0`.
- Échelle : renvoie le **cosinus 0-1** ; le **×100 n'a lieu qu'à l'agrégation (#27)**, cohérent avec `ScoreResult.score_embedding` (`Field(ge=0.0, le=1.0)`).
- `scoring_node` reste un **stub** (#28).

### Tests — `tests/test_scoring.py`
+11 cas : `_cosinus` pur (identiques/orthogonaux/opposés/vecteur nul/valeur connue 1/√2), `_score_embedding` (court-circuit ICP absent **sans appeler Ollama**, borne 0-1, clamp d'un cosinus négatif, upsert avec `prospect_id` + payload indexable `campagne_id`/`code_naf`/`departement`, **pas** d'upsert sans id, texte reprenant les champs). **Ollama et Qdrant mockés** (`monkeypatch`) — aucun réseau.

`pytest -m "not integration"` : **255 passed, 3 deselected**.

### Suite
Base `main`, pas d'empilement. Prochaine PR : **#25 LLM Claude** (même fichier `scoring_agent.py` → à brancher après fusion de #26). #25 a besoin des deps de #90 (`anthropic`/`jinja2`, déjà sur main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)