### PR TITLE
feat(#25): couche LLM du scoring — _score_llm (Claude, sortie structurée)

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -14,16 +14,29 @@ Barème détaillé et échelles : `docs/SCORING.md`.
 """
 from __future__ import annotations
 
+import json
+import logging
 import math
 from datetime import date
+from pathlib import Path
+
+import anthropic
+from jinja2 import Environment, FileSystemLoader
 
 # ⟳ RÉUTILISÉ, jamais redéfini : l'exclusion par mot entier (garde légale/business,
 # règle #4) a une seule source de vérité, partagée avec le nettoyage (#19).
 from agents.nettoyage_agent import _matche_exclusion
+from config.settings import get_settings
 from models.criteres import CriteresCiblage
 from models.prospect import Prospect
 from utils.db import upsert_prospect_embedding
 from utils.embeddings import get_embedding
+
+logger = logging.getLogger(__name__)
+
+# Environnement Jinja des templates de prompt (rendus dynamiquement depuis l'ICP, #25).
+_PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+_JINJA_ENV = Environment(loader=FileSystemLoader(str(_PROMPTS_DIR)), autoescape=False)
 
 
 # --- Couche 1 : règles métier (#24) -----------------------------------------
@@ -120,6 +133,119 @@ def _score_regles(prospect: Prospect, criteres: CriteresCiblage) -> int:
         score -= 30
 
     return max(0, min(100, score))
+
+
+# --- Couche 2 : scoring LLM Claude (#25) ------------------------------------
+# API Claude UNIQUEMENT (règle #6), AsyncAnthropic (règle #8). Sortie STRUCTURÉE
+# (output_config.format) plutôt que parsing regex. Modèle = settings.claude_scoring_model
+# (défaut Haiku 4.5), jamais codé en dur (règle #6). Code AGNOSTIQUE du modèle : on ne
+# fixe NI effort, NI temperature, NI thinking (Haiku refuse effort ; Sonnet 5 refuse
+# temperature/top_p) — défauts + schéma suffisent pour une classification bornée. Repli
+# sur le score règles si Claude est indisponible. Voir docs/SCORING.md (couche 2).
+
+# ⚠️ La sortie structurée ne contraint NI les bornes (minimum/maximum) NI la longueur
+# (minLength) — non supportés. "score" est donc borné [0, 100] côté code.
+_SCORE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "score": {"type": "integer"},
+        "justification": {"type": "string"},
+        "signaux_positifs": {"type": "array", "items": {"type": "string"}},
+        "signaux_negatifs": {"type": "array", "items": {"type": "string"}},
+        "priorite": {"type": "string", "enum": ["haute", "moyenne", "basse"]},
+    },
+    "required": [
+        "score", "justification", "signaux_positifs", "signaux_negatifs", "priorite",
+    ],
+    "additionalProperties": False,
+}
+
+
+def rendre_system(criteres: CriteresCiblage, client_nom: str | None = None) -> str:
+    """Rend le prompt système depuis l'ICP du client. À rendre UNE FOIS par campagne
+    (candidat au cache), réutilisé pour chaque prospect. Aucune valeur métier codée
+    en dur — tout vient de `criteres` (règle #3)."""
+    return _JINJA_ENV.get_template("scorer_system.txt.j2").render(
+        client_nom=client_nom,
+        description_icp=criteres.description_icp,
+        codes_naf=criteres.codes_naf,
+        effectif_min=criteres.effectif_min,
+        effectif_max=criteres.effectif_max,
+        mots_cles_positifs=criteres.mots_cles_positifs,
+        mots_cles_negatifs=criteres.mots_cles_negatifs,
+    )
+
+
+def rendre_user(prospect: Prospect, mots_cles_detectes: list[str] | None = None) -> str:
+    """Rend le prompt utilisateur pour un prospect donné (par prospect)."""
+    return _JINJA_ENV.get_template("scorer_user.txt.j2").render(
+        nom_entreprise=prospect.nom_entreprise,
+        siret=prospect.siret,
+        code_naf=prospect.code_naf,
+        libelle_naf=prospect.libelle_naf,
+        effectif_estime=prospect.effectif_estime,
+        ville=prospect.ville,
+        departement=prospect.departement,
+        site_web=prospect.site_web,
+        mots_cles_detectes=mots_cles_detectes or [],
+    )
+
+
+def _fallback_llm(score_regles: int, raison: str) -> dict:
+    """Repli déterministe quand Claude est indisponible ou sa réponse inexploitable :
+    le score LLM emprunte le score règles (comportement prévu par docs/SCORING.md)."""
+    return {
+        "score": max(0, min(100, int(score_regles))),
+        "justification": f"Repli sur le score règles ({raison}).",
+        "signaux_positifs": [],
+        "signaux_negatifs": [],
+        "priorite": "moyenne",
+    }
+
+
+async def _score_llm(
+    client: anthropic.AsyncAnthropic,
+    system_rendu: str,
+    user_rendu: str,
+    score_regles_fallback: int,
+) -> dict:
+    """Score LLM 0-100 + justification/signaux/priorité via Claude (sortie structurée).
+
+    Renvoie un dict `{score, justification, signaux_positifs, signaux_negatifs,
+    priorite}`. En cas d'indisponibilité de l'API (ou de réponse inexploitable),
+    repli sur le score règles. Le mapping vers `ScoreResult` (`score` -> `score_llm`,
+    `justification` -> `justification_llm`) est fait à l'agrégation (#27).
+    """
+    settings = get_settings()
+    try:
+        resp = await client.messages.create(
+            model=settings.claude_scoring_model,        # jamais codé en dur (règle #6)
+            max_tokens=400,
+            system=[{                                    # rendu 1×/campagne, candidat au cache
+                "type": "text",
+                "text": system_rendu,
+                "cache_control": {"type": "ephemeral"},
+            }],
+            messages=[{"role": "user", "content": user_rendu}],
+            output_config={"format": {"type": "json_schema", "schema": _SCORE_SCHEMA}},
+            # ⚠️ NI effort, NI temperature, NI thinking (agnostique du modèle — cf. en-tête).
+        )
+        texte = next(b.text for b in resp.content if getattr(b, "type", None) == "text")
+        data = json.loads(texte)
+    except anthropic.APIError as exc:                    # rate-limit / status / connexion
+        logger.warning("Scoring LLM indisponible (%s) — repli sur le score règles.", exc)
+        return _fallback_llm(score_regles_fallback, "Claude indisponible")
+    except (StopIteration, ValueError, TypeError) as exc:  # JSON tronqué / bloc texte absent
+        logger.warning("Réponse LLM inexploitable (%s) — repli sur le score règles.", exc)
+        return _fallback_llm(score_regles_fallback, "réponse LLM inexploitable")
+
+    return {
+        "score": max(0, min(100, int(data.get("score", score_regles_fallback)))),
+        "justification": str(data.get("justification", "")),
+        "signaux_positifs": list(data.get("signaux_positifs", [])),
+        "signaux_negatifs": list(data.get("signaux_negatifs", [])),
+        "priorite": data.get("priorite", "moyenne"),
+    }
 
 
 # --- Couche 3 : similarité embeddings ICP (#26) -----------------------------

--- a/prompts/scorer_system.txt.j2
+++ b/prompts/scorer_system.txt.j2
@@ -1,17 +1,31 @@
-{# Template Jinja — prompt système du scorer Claude (issue #11 STUB).
-   Rendu dynamiquement depuis l'ICP du client (criteres_ciblage / icp_profiles
-   en base) — jamais figé, aucune valeur métier codée en dur (CLAUDE.md #3).
-   Implémentation détaillée portée par les issues de scoring (docs/SCORING.md). #}
-Tu es un assistant expert en qualification B2B pour le client « {{ client_nom | default("(non renseigné)") }} ».
+{# Prompt système du scorer Claude (issue #25). Rendu dynamiquement depuis l'ICP
+   du client (criteres_ciblage / icp_profiles) — jamais figé, aucune valeur métier
+   codée en dur (CLAUDE.md #3). Rendu UNE FOIS par campagne (candidat au cache),
+   réutilisé pour chaque prospect. Voir docs/SCORING.md (couche 2). #}
+Tu es un assistant expert en qualification commerciale B2B pour le client « {{ client_nom | default("(non renseigné)", true) }} ».
 
-Profil cible (ICP) du client :
-- Description : {{ description_icp | default("(non renseignée)") }}
-- Codes NAF ciblés : {{ codes_naf | join(", ") | default("(tous)") }}
-- Tranche d'effectif : {{ effectif_min | default("") }}–{{ effectif_max | default("(non borné)") }}
-- Mots-clés positifs : {{ mots_cles_positifs | join(", ") | default("(aucun)") }}
-- Mots-clés négatifs (exclusions) : {{ mots_cles_negatifs | join(", ") | default("(aucun)") }}
+Profil client idéal (ICP) défini par ce client :
+- Description : {{ description_icp | default("(non renseignée)", true) }}
+- Codes NAF ciblés : {{ codes_naf | join(", ") | default("(tous)", true) }}
+- Tranche d'effectif visée : {{ effectif_min | default("0", true) }}–{{ effectif_max | default("(non borné)", true) }} salariés
+- Mots-clés positifs (signaux recherchés) : {{ mots_cles_positifs | join(", ") | default("(aucun)", true) }}
+- Mots-clés négatifs (exclusions) : {{ mots_cles_negatifs | join(", ") | default("(aucun)", true) }}
 
-Règle absolue : un prospect qui matche un mot-clé négatif doit recevoir un
-score final de 0, sans exception.
+Ta mission : évaluer l'adéquation commerciale de chaque prospect avec cet ICP, sur
+une échelle de 0 à 100, en pondérant les critères selon la description ci-dessus.
 
-{# TODO(issue dédiée) : instructions de scoring détaillées + format de sortie JSON attendu. #}
+Pistes d'évaluation (à adapter au secteur décrit, pas une grille rigide) :
+- adéquation de l'activité (code/libellé NAF) avec la cible ;
+- taille d'entreprise cohérente avec la fourchette d'effectif ;
+- présence des signaux positifs / absence de signaux d'exclusion ;
+- maturité et pertinence (site web, ancienneté, zone) si elles comptent pour ce secteur.
+
+Règle absolue : un prospect qui correspond à un mot-clé négatif (exclusion) reçoit un
+score de 0, sans exception.
+
+Contraintes de sortie :
+- Réponds UNIQUEMENT par l'objet JSON imposé par le schéma — aucun texte avant ni après.
+- "score" : entier de 0 à 100.
+- "justification" : une phrase de 20 à 50 mots, en français, au regard de cet ICP.
+- "signaux_positifs" / "signaux_negatifs" : listes de courtes chaînes (éventuellement vides).
+- "priorite" : "haute", "moyenne" ou "basse".

--- a/prompts/scorer_user.txt.j2
+++ b/prompts/scorer_user.txt.j2
@@ -1,16 +1,14 @@
-{# Template Jinja — prompt utilisateur du scorer (issue #11 STUB).
-   Données prospect injectées au runtime. Rendu depuis l'ICP du client,
-   jamais figé (CLAUDE.md #3, #6). Implémentation détaillée : issues scoring. #}
-Évalue ce prospect B2B face à l'ICP du client.
+{# Prompt utilisateur du scorer (issue #25). Données d'UN prospect injectées au
+   runtime, rendues par prospect. Aucune valeur métier codée en dur (CLAUDE.md #3).
+   Le format de sortie JSON est imposé par output_config.format côté appel. #}
+Évalue ce prospect B2B au regard de l'ICP du client.
 
-Entreprise : {{ nom_entreprise | default("(inconnu)") }}
-SIRET : {{ siret | default("(inconnu)") }}
-Code NAF : {{ code_naf | default("(inconnu)") }} — {{ libelle_naf | default("") }}
-Effectif estimé : {{ effectif_estime | default("(inconnu)") }}
-Ville / Département : {{ ville | default("?") }} ({{ departement | default("??") }})
-Site web : {{ site_web | default("(aucun)") }}
-Mots-clés détectés (enrichissement) : {{ mots_cles_detectes | join(", ") | default("(aucun)") }}
+Entreprise : {{ nom_entreprise | default("(inconnu)", true) }}
+SIRET : {{ siret | default("(inconnu)", true) }}
+Code NAF : {{ code_naf | default("(inconnu)", true) }} — {{ libelle_naf | default("", true) }}
+Effectif estimé : {{ effectif_estime | default("(inconnu)", true) }}
+Ville / Département : {{ ville | default("?", true) }} ({{ departement | default("??", true) }})
+Site web : {{ site_web | default("(aucun)", true) }}
+Mots-clés détectés (enrichissement) : {{ mots_cles_detectes | join(", ") | default("(aucun)", true) }}
 
-Renvoie un score final sur 100 et une justification courte.
-
-{# TODO(issue dédiée) : schéma JSON de sortie strict à documenter. #}
+Renvoie l'objet JSON de score demandé (score 0-100, justification, signaux, priorité).

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -5,16 +5,24 @@ Couche règles (#24) : sous-scorers (`_score_effectif`, `_score_anciennete`,
 ancienneté, présence, géo, mots-clés, pénalités, exclusion #4, plafond 0-100).
 Couche embeddings (#26) : `_cosinus` (Python pur) + `_score_embedding` (Ollama et
 Qdrant mockés — aucun réseau ; cosinus borné 0-1, ICP absent → 0.0, upsert
-conditionnel au `prospect_id`). Valeurs métier depuis `CriteresCiblage` (règle #3).
+conditionnel au `prospect_id`).
+Couche LLM (#25) : rendu des prompts Jinja depuis l'ICP (`rendre_system`/`rendre_user`)
++ `_score_llm` (client Anthropic FAUX — aucun réseau) : sortie structurée, requête
+agnostique du modèle (ni effort/temperature/thinking), bornage 0-100, repli sur le
+score règles. Valeurs métier depuis `CriteresCiblage` (règle #3).
 """
 from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import math
 import uuid
 from datetime import date, timedelta
+from types import SimpleNamespace
 
+import anthropic
+import httpx
 import pytest
 
 from agents import scoring_agent as sa   # pour monkeypatcher get_embedding / upsert
@@ -23,9 +31,13 @@ from agents.scoring_agent import (
     _score_anciennete,
     _score_effectif,
     _score_embedding,
+    _score_llm,
     _score_mots_cles_positifs,
     _score_regles,
+    rendre_system,
+    rendre_user,
 )
+from config.settings import get_settings
 from models.criteres import CriteresCiblage
 from models.prospect import Prospect
 
@@ -345,3 +357,127 @@ def test_score_embedding_texte_reprend_les_champs(monkeypatch):
 
     for attendu in ("Garage Martin", "Réparation auto", "Paris", "75", "8"):
         assert attendu in vu["text"]
+
+
+# --- Couche 2 : rendu des prompts Jinja depuis l'ICP (#25) ------------------
+def test_rendre_system_reprend_l_icp():
+    crit = _criteres(
+        description_icp="Garages automobiles indépendants",
+        codes_naf=["4520Z"], effectif_min=2, effectif_max=15,
+        mots_cles_positifs=["carrosserie"], mots_cles_negatifs=["norauto"],
+    )
+    s = rendre_system(crit, client_nom="AssurPro")
+    for attendu in ("AssurPro", "Garages automobiles indépendants", "4520Z",
+                    "carrosserie", "norauto"):
+        assert attendu in s
+    assert "JSON" in s   # contrat de sortie présent
+
+
+def test_rendre_system_defaut_sans_client_ni_valeurs():
+    s = rendre_system(_criteres(), client_nom=None)
+    assert "None" not in s              # default(..., true) évite le rendu littéral de None
+    assert "(non renseigné)" in s
+
+
+def test_rendre_user_reprend_le_prospect():
+    p = _p(nom="Garage Martin", code_naf="4520Z", libelle_naf="Réparation auto",
+           effectif_estime=8, ville="Paris", departement="75", site_web="https://x.fr")
+    u = rendre_user(p, mots_cles_detectes=["diagnostic"])
+    for attendu in ("Garage Martin", "4520Z", "Réparation auto", "8", "Paris",
+                    "75", "diagnostic"):
+        assert attendu in u
+
+
+def test_rendre_user_champs_absents_pas_de_None():
+    u = rendre_user(_p())               # la plupart des champs à None
+    assert "None" not in u
+
+
+# --- Couche 2 : _score_llm (client Anthropic FAUX — aucun réseau) -----------
+class _FakeMessages:
+    def __init__(self, resp=None, exc=None):
+        self._resp, self._exc = resp, exc
+        self.calls: list[dict] = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._exc is not None:
+            raise self._exc
+        return self._resp
+
+
+class _FakeClient:
+    """Imite anthropic.AsyncAnthropic pour _score_llm — pas de réseau, pas de clé."""
+    def __init__(self, resp=None, exc=None):
+        self.messages = _FakeMessages(resp, exc)
+
+
+def _resp_json(payload: dict) -> SimpleNamespace:
+    bloc = SimpleNamespace(type="text", text=json.dumps(payload))
+    return SimpleNamespace(content=[bloc])
+
+
+_PAYLOAD_OK = {
+    "score": 72,
+    "justification": "Bonne adéquation avec l'ICP : activité et taille cohérentes.",
+    "signaux_positifs": ["carrosserie", "avis google"],
+    "signaux_negatifs": [],
+    "priorite": "haute",
+}
+
+
+def test_score_llm_parse_sortie_structuree():
+    client = _FakeClient(resp=_resp_json(_PAYLOAD_OK))
+    r = asyncio.run(_score_llm(client, "sys", "usr", score_regles_fallback=50))
+    assert r["score"] == 72
+    assert r["priorite"] == "haute"
+    assert r["signaux_positifs"] == ["carrosserie", "avis google"]
+    assert "adéquation" in r["justification"]
+
+
+def test_score_llm_requete_agnostique_du_modele():
+    """La requête utilise le modèle configuré + sortie structurée + cache, et n'inclut
+    NI temperature/top_p NI effort/thinking (contrat multi-modèle Haiku↔Sonnet)."""
+    client = _FakeClient(resp=_resp_json(_PAYLOAD_OK))
+    asyncio.run(_score_llm(client, "SYS", "USR", score_regles_fallback=50))
+    kw = client.messages.calls[0]
+    assert kw["model"] == get_settings().claude_scoring_model
+    assert kw["output_config"]["format"]["type"] == "json_schema"
+    assert kw["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert kw["system"][0]["text"] == "SYS"
+    assert "temperature" not in kw
+    assert "top_p" not in kw
+    assert "thinking" not in kw
+    assert "effort" not in kw.get("output_config", {})
+
+
+def test_score_llm_borne_le_score():
+    haut = _FakeClient(resp=_resp_json({**_PAYLOAD_OK, "score": 150}))
+    bas = _FakeClient(resp=_resp_json({**_PAYLOAD_OK, "score": -10}))
+    assert asyncio.run(_score_llm(haut, "s", "u", 50))["score"] == 100
+    assert asyncio.run(_score_llm(bas, "s", "u", 50))["score"] == 0
+
+
+def test_score_llm_repli_sur_erreur_api():
+    exc = anthropic.APIConnectionError(
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    )
+    client = _FakeClient(exc=exc)
+    r = asyncio.run(_score_llm(client, "s", "u", score_regles_fallback=63))
+    assert r["score"] == 63
+    assert r["priorite"] == "moyenne"
+    assert "Repli" in r["justification"]
+
+
+def test_score_llm_repli_sur_json_invalide():
+    resp = SimpleNamespace(content=[SimpleNamespace(type="text", text="pas du json")])
+    client = _FakeClient(resp=resp)
+    r = asyncio.run(_score_llm(client, "s", "u", score_regles_fallback=41))
+    assert r["score"] == 41
+    assert "Repli" in r["justification"]
+
+
+def test_score_llm_repli_sans_bloc_texte():
+    client = _FakeClient(resp=SimpleNamespace(content=[]))   # next(...) -> StopIteration
+    r = asyncio.run(_score_llm(client, "s", "u", score_regles_fallback=55))
+    assert r["score"] == 55


### PR DESCRIPTION
> ## ⚠️ EMPILÉE SUR #26 — ORDRE DE FUSION IMPOSÉ
> **Cette PR est basée sur la branche de #26 (PR #92), PAS sur `main`** (même fichier `scoring_agent.py` + `test_scoring.py`).
> **Fusionner #92 (#26) D'ABORD.** Ensuite : rebaser cette PR sur `main` à jour (ou GitHub retargette la base) et **vérifier le contenu sur `main` avec `git ls-tree`** (anti-piège des PR empilées) avant de fusionner celle-ci.

**Sprint 3, PR 3/4 du cœur scoring.** Implémente la **couche 2 (scoring LLM Claude)** — sortie structurée, prompts rendus depuis l'ICP. `Closes #25`.

### Contenu
- **`prompts/scorer_{system,user}.txt.j2`** complétés : instructions de scoring + contrat de sortie, rendus **dynamiquement depuis l'ICP** (`rendre_system` / `rendre_user`) — aucune valeur métier codée en dur (règle #3), `default(..., true)` pour un rendu propre des champs absents.
- **`_score_llm(client, system, user, fallback)`** : `AsyncAnthropic` (règle #8), **API Claude uniquement** (règle #6), modèle `settings.claude_scoring_model`. **Sortie structurée** `output_config.format` (json_schema) + `cache_control` sur le system (rendu 1×/campagne). **Repli sur le score règles** sur `anthropic.APIError` ou réponse inexploitable.
- **Agnostique du modèle** (le piège corrigé) : ni `effort`, ni `temperature`, ni `thinking` — Haiku 4.5 **refuse** `effort`, Sonnet 5 **refuse** `temperature`/`top_p`. Vérifié sur la doc *structured outputs* (Haiku 4.5 supporté ; `minimum`/`maximum`/`minLength` non supportés → `score` borné côté code).
- `scoring_node` reste un **stub** (#28).

### Tests — `tests/test_scoring.py`
+10 cas : rendu des prompts depuis l'ICP (system reprend client/description/NAF/mots-clés, défauts sans `None`, user reprend les champs prospect) ; `_score_llm` avec un **client Anthropic FAUX** (parse de la sortie structurée, **requête sans `temperature`/`top_p`/`effort`/`thinking`** et modèle configuré, bornage 0-100, replis API/JSON-invalide/bloc-absent). **Aucun réseau, aucune clé API.**

`pytest -m "not integration"` : **265 passed, 3 deselected**.

### Prérequis d'environnement
`anthropic` + `jinja2` (déjà dans `requirements.txt` via #90, sur `main`) doivent être installés (`pip install -r requirements.txt`) — l'import `from anthropic import ...` en tête de `scoring_agent.py` en dépend.

Prochaine PR : **#27 agrégation + persistance** (somme pondérée, `statut`, extension de `save_score`) — à brancher après fusion de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)