### PR TITLE
fix(#28): init_campagne résout le vecteur ICP (pas le point_id) — gap intégration

### DIFF
--- a/graph/workflow.py
+++ b/graph/workflow.py
@@ -51,7 +51,7 @@ async def init_campagne(etat: EtatAgent) -> EtatAgent:
 
     Returns:
         `etat` enrichi avec `client_id`, `criteres` (CriteresCiblage),
-        `icp_embedding` (str qdrant_point_id ou None), `config_scoring` (dict).
+        `icp_embedding` (**vecteur** `list[float]` de l'ICP, ou None), `config_scoring`.
     """
     campagne_id_raw = etat.get("campagne_id")
     if not campagne_id_raw:
@@ -140,9 +140,6 @@ async def init_campagne(etat: EtatAgent) -> EtatAgent:
 
         # 4. qdrant_point_id de l'ICP (peut être None si #12 non exécuté).
         qdrant_point_id = campagne_row["qdrant_point_id"]
-        icp_embedding_ref: str | None = (
-            str(qdrant_point_id) if qdrant_point_id is not None else None
-        )
 
     # NOTE : on n'appelle PAS `db.close()` ici. Le pool PG et le client Qdrant
     # sont des singletons (utils.db) partagés par tous les nodes du graphe (#28)
@@ -151,11 +148,20 @@ async def init_campagne(etat: EtatAgent) -> EtatAgent:
     # ressort de l'orchestrateur (run/main.py) en fin de graphe — pas d'un node.
     # `scripts/init_icp.py` ferme son pool car il est standalone (hors graphe).
 
+    # 4b. Résolution du VECTEUR ICP (Qdrant), hors connexion PG. `EtatAgent.
+    # icp_embedding` est typé `list[float]` : le scoring embeddings (#26) attend le
+    # VECTEUR, pas le point_id. On le résout via `get_icp_embedding(point_id)`.
+    # None si l'ICP n'est pas encore embarqué (#12 non exécuté) ou si le point est
+    # absent de Qdrant → la couche embeddings reste neutre (0.0), pas de plantage.
+    icp_embedding: list[float] | None = None
+    if qdrant_point_id is not None:
+        icp_embedding = await db.get_icp_embedding(str(qdrant_point_id))
+
     # 5. Peuplement de l'état partagé (consommé par les nodes suivants).
     etat["campagne_id"] = str(campagne_uuid)
     etat["client_id"] = str(campagne_row["client_id"])
     etat["criteres"] = critere
-    etat["icp_embedding"] = icp_embedding_ref
+    etat["icp_embedding"] = icp_embedding
     etat["config_scoring"] = dict(campagne_row["config_scoring"] or {})
     return etat
 

--- a/tests/test_init_campagne.py
+++ b/tests/test_init_campagne.py
@@ -3,7 +3,7 @@
 Couvre les 2 critères d'acceptance :
 - AC1 : `init_campagne` retourne un `EtatAgent` avec tous les critères de la
   campagne correctement chargés (codes NAF, départements, effectif min/max,
-  ancienneté min, mots-clés +/-, ICP embedding point id, config_scoring).
+  ancienneté min, mots-clés +/-, ICP embedding **vecteur** résolu, config_scoring).
 - AC2 : Erreur claire et explicite si la campagne ou ses critères n'existent pas
   (fail fast, pas de valeurs par défaut silencieuses).
 
@@ -189,7 +189,10 @@ async def test_ac1_unit_charge_tous_les_criteres() -> None:
 
     pool, conn = _make_pool_mock(campagne_row, critere, icp_point_id)
 
-    with patch("graph.workflow.db.get_pg_pool", new_callable=AsyncMock, return_value=pool):
+    fake_vecteur = [0.1, 0.2, 0.3]  # vecteur ICP résolu depuis Qdrant (mocké)
+    with patch("graph.workflow.db.get_pg_pool", new_callable=AsyncMock, return_value=pool), \
+         patch("graph.workflow.db.get_icp_embedding", new_callable=AsyncMock,
+               return_value=fake_vecteur) as mock_get_icp:
         etat = await init_campagne({"campagne_id": CAMPAGNE_ID})
 
     # EtatAgent peuplé correctement.
@@ -207,8 +210,9 @@ async def test_ac1_unit_charge_tous_les_criteres() -> None:
     assert crit.exiger_email is False
     assert crit.mots_cles_positifs == ["qualite", "service"]
     assert crit.mots_cles_negatifs == ["exclusion1", "exclusion2"]
-    # ICP embedding point id + config_scoring propagés.
-    assert etat["icp_embedding"] == icp_point_id or etat.get("icp_point_id") == icp_point_id
+    # ICP embedding : le VECTEUR est résolu depuis Qdrant via le qdrant_point_id.
+    mock_get_icp.assert_awaited_once_with(icp_point_id)
+    assert etat["icp_embedding"] == fake_vecteur
     assert etat["config_scoring"]["poids_llm"] == 0.45
 
 
@@ -228,10 +232,12 @@ async def test_ac1_unit_embedding_optionnel_si_pas_icp_profile() -> None:
 
     pool, _ = _make_pool_mock(campagne_row, critere, None)
 
-    with patch("graph.workflow.db.get_pg_pool", new_callable=AsyncMock, return_value=pool):
+    with patch("graph.workflow.db.get_pg_pool", new_callable=AsyncMock, return_value=pool), \
+         patch("graph.workflow.db.get_icp_embedding", new_callable=AsyncMock) as mock_get_icp:
         etat = await init_campagne({"campagne_id": CAMPAGNE_ID})
 
     assert etat["icp_embedding"] is None
+    mock_get_icp.assert_not_awaited()   # court-circuit : pas de point_id → pas d'appel Qdrant
     assert isinstance(etat["criteres"], CriteresCiblage)
 
 


### PR DESCRIPTION
**Gap d'intégration découvert en préparant #28.** Base `main`, **disjoint** du chaînage scoring (#92/#93) — touche seulement `graph/workflow.py` + son test.

### Le bug
`init_campagne` (#16) posait `etat["icp_embedding"] = str(qdrant_point_id)` — un **point_id (str)**. Mais :
- `EtatAgent.icp_embedding` est typé **`list[float] | None`** (un vecteur),
- et le scoring embeddings (#26) fait `_cosinus(vecteur, icp_embedding)` → **planterait** sur une str.

Au câblage du graphe (#28), la couche embeddings aurait donc cassé (ou produit du bruit). Personne ne le voyait car `get_icp_embedding` n'est appelé nulle part aujourd'hui (persistance non câblée — cf. [prep #28](../blob/main/) / mémo).

### Le fix
- `init_campagne` **résout `point_id → vecteur`** via `db.get_icp_embedding(point_id)` (appel Qdrant, hors connexion PG). Cohérent avec le type déclaré + le contrat de #26 (aucun changement à #26).
- **Court-circuit** : si `qdrant_point_id` est `None` (ICP non embarqué, #12 non exécuté), aucun appel Qdrant → `icp_embedding = None` → couche embeddings neutre (`0.0`), pas de plantage.

### Tests
Les 2 tests unitaires AC1 de `test_init_campagne.py` mockent désormais `get_icp_embedding` : (a) vecteur résolu + appelé avec le bon point_id, (b) court-circuit vérifié quand pas de point_id. `pytest -m "not integration"` : **244 passed, 3 deselected**.

Débloque proprement le câblage de la couche embeddings dans #28. Ne ferme pas d'issue (fix de prep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)