### PR TITLE
feat(#30): scaffolding LangSmith (config + helper) — traçage câblé à #28

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -69,6 +69,16 @@ class Settings(BaseSettings):
     # campagne — poser un budget en prod, cf. suivi de coûts #23).
     opposition_budget_credits: int | None = None
 
+    # ---------- LangSmith (traces + coûts LLM — #30) ----------
+    # Observabilité optionnelle, DÉSACTIVÉE par défaut. Convention LANGCHAIN_*
+    # (cf. .env.example) — acceptée par le SDK langsmith. Le traçage effectif des
+    # appels Claude est câblé à l'assemblage du graphe (#28) ; ici, seulement la
+    # config, propagée dans l'environnement par utils/tracing.configure_tracing().
+    langchain_tracing_v2: bool = False
+    langchain_api_key: str = ""
+    langchain_project: str = "prospection-b2b"
+    langchain_endpoint: str = ""  # vide = endpoint LangSmith cloud par défaut
+
     @property
     def postgres_dsn(self) -> str:
         return (

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,10 @@ anthropic>=0.40,<1.0
 # Rendu des prompts de scoring depuis l'ICP client (issue #25), jamais figé (règle #3).
 jinja2>=3.1,<4.0
 
+# Observabilité LLM (issue #30) — traces + coûts. Config via LANGCHAIN_* (utils/tracing).
+# Traçage effectif des appels Claude câblé à l'assemblage du graphe (#28).
+langsmith>=0.1,<1.0
+
 # --- Dev (tests) ---
 pytest>=8.0,<9.0
 pytest-asyncio>=0.23,<0.25

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,65 @@
+"""Tests de la config LangSmith (#30) — purs, sans réseau, sans langsmith installé.
+
+`configure_tracing` ne fait que propager `LANGCHAIN_*` de `settings` vers
+l'environnement. On mocke `settings` et on isole `os.environ` par test.
+"""
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+from utils import tracing
+
+
+def _fake_settings(**o) -> SimpleNamespace:
+    base = dict(
+        langchain_tracing_v2=False,
+        langchain_api_key="",
+        langchain_project="prospection-b2b",
+        langchain_endpoint="",
+    )
+    base.update(o)
+    return SimpleNamespace(**base)
+
+
+def test_desactive_par_defaut(monkeypatch):
+    monkeypatch.setattr(tracing, "get_settings", lambda: _fake_settings())
+    assert tracing.configure_tracing() is False
+
+
+def test_active_avec_cle_pose_les_env(monkeypatch):
+    # Isole os.environ (copie restaurée en fin de test).
+    monkeypatch.setattr(os, "environ", dict(os.environ))
+    monkeypatch.setattr(tracing, "get_settings", lambda: _fake_settings(
+        langchain_tracing_v2=True,
+        langchain_api_key="ls-secret",
+        langchain_project="proj-x",
+        langchain_endpoint="https://eu.smith.langchain.com",
+    ))
+
+    assert tracing.configure_tracing() is True
+    assert os.environ["LANGCHAIN_TRACING_V2"] == "true"
+    assert os.environ["LANGCHAIN_API_KEY"] == "ls-secret"
+    assert os.environ["LANGCHAIN_PROJECT"] == "proj-x"
+    assert os.environ["LANGCHAIN_ENDPOINT"] == "https://eu.smith.langchain.com"
+
+
+def test_active_sans_cle_ne_trace_pas(monkeypatch):
+    """Traçage demandé mais clé absente → désactivé (pas de trace partielle)."""
+    monkeypatch.setattr(os, "environ", dict(os.environ))
+    monkeypatch.setattr(tracing, "get_settings", lambda: _fake_settings(
+        langchain_tracing_v2=True, langchain_api_key="",
+    ))
+    assert tracing.configure_tracing() is False
+    # Rien n'a été forcé dans l'environnement.
+    assert os.environ.get("LANGCHAIN_API_KEY", "") == ""
+
+
+def test_endpoint_optionnel_non_pose_si_vide(monkeypatch):
+    monkeypatch.setattr(os, "environ", dict(os.environ))
+    monkeypatch.delenv("LANGCHAIN_ENDPOINT", raising=False)
+    monkeypatch.setattr(tracing, "get_settings", lambda: _fake_settings(
+        langchain_tracing_v2=True, langchain_api_key="ls-secret", langchain_endpoint="",
+    ))
+    assert tracing.configure_tracing() is True
+    assert "LANGCHAIN_ENDPOINT" not in os.environ

--- a/utils/tracing.py
+++ b/utils/tracing.py
@@ -1,0 +1,54 @@
+"""Configuration LangSmith — traces + coûts LLM (issue #30).
+
+Bootstrap **par variables d'environnement** (mécanisme LangSmith confirmé). Ce
+module n'importe PAS `langsmith` : il ne fait que propager la config `LANGCHAIN_*`
+depuis `settings` vers l'environnement, pour que le SDK langsmith la capte quand le
+graphe (#28) instancie et trace le client Claude.
+
+⚠️ Périmètre #30 = config uniquement. Le traçage EFFECTIF des appels Claude
+(`@traceable` / wrapper sur le call site) est câblé à l'assemblage du graphe (#28) —
+ça touche `agents/scoring_agent.py`, hors de ce module.
+
+Convention `LANGCHAIN_*` alignée sur `.env.example` (acceptée par le SDK langsmith).
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from config.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def configure_tracing() -> bool:
+    """Active le traçage LangSmith si `LANGCHAIN_TRACING_V2` **et** une clé API sont
+    présents, en propageant `LANGCHAIN_*` dans l'environnement pour le SDK langsmith.
+
+    À appeler une fois au démarrage (CLI #29 / orchestrateur). Idempotent.
+
+    Returns:
+        True si le traçage est activé ; False sinon — désactivé, ou clé absente
+        (on ne trace jamais « à moitié » en silence).
+    """
+    settings = get_settings()
+
+    if not settings.langchain_tracing_v2:
+        return False
+
+    if not settings.langchain_api_key:
+        logger.warning(
+            "LangSmith : LANGCHAIN_TRACING_V2 activé mais LANGCHAIN_API_KEY absente "
+            "— traçage désactivé (pas de trace partielle silencieuse)."
+        )
+        return False
+
+    os.environ["LANGCHAIN_TRACING_V2"] = "true"
+    os.environ["LANGCHAIN_API_KEY"] = settings.langchain_api_key
+    if settings.langchain_project:
+        os.environ["LANGCHAIN_PROJECT"] = settings.langchain_project
+    if settings.langchain_endpoint:
+        os.environ["LANGCHAIN_ENDPOINT"] = settings.langchain_endpoint
+
+    logger.info("LangSmith activé (projet=%s).", settings.langchain_project or "default")
+    return True


### PR DESCRIPTION
**Scaffolding LangSmith (#30), périmètre config uniquement.** Base `main`, **disjoint** du chaînage scoring (#92/#93) et du fix #94.

### Contenu
- **`config/settings.py`** — section LangSmith : `langchain_tracing_v2` (bool, **False** par défaut), `langchain_api_key`, `langchain_project`, `langchain_endpoint`. Convention `LANGCHAIN_*` alignée sur `.env.example` (le SDK langsmith l'accepte).
- **`utils/tracing.py`** — `configure_tracing()` propage `LANGCHAIN_*` dans l'environnement **si** le traçage est activé **et** la clé présente ; sinon `False` (pas de trace partielle silencieuse). **N'importe pas `langsmith`** — bootstrap par variables d'environnement, le seul mécanisme confirmé par la doc.
- **`requirements.txt`** — `+ langsmith>=0.1,<1.0`.

### ⚠️ Ce que ça NE fait PAS (volontairement)
Le **traçage effectif des appels Claude** (`@traceable` / wrapper sur le call site) est câblé à l'**assemblage du graphe (#28)** — ça touche `agents/scoring_agent.py`, dans le chaînage scoring. Vérifié sur la doc LangSmith : **pas de `wrap_anthropic` confirmé** → on ne l'invente pas ; #28 utilisera `@traceable` (confirmé) ou l'API vérifiée à ce moment-là.

### Tests
`tests/test_tracing.py` : +4 cas (désactivé par défaut, activation pose les env, clé absente → pas de trace, endpoint optionnel). Purs, sans réseau, sans langsmith installé. `pytest -m "not integration"` : **248 passed, 3 deselected**.

Adresse **partiellement** #30 (config) — la couche traçage reste à câbler en #28. Ne ferme pas l'issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)