### PR TITLE
feat(#27): agrégation score final + persistance (statut + compteur qualifiés)

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -1,8 +1,8 @@
 """Agent de scoring hybride 3 couches (règles + Claude + embeddings).
 
-Issue #11 — squelette. **Couche 1 (règles métier, #24) et couche 3 (embeddings,
-#26) implémentées ci-dessous.** La couche 2 (LLM Claude, #25), l'agrégation/
-persistance (#27) et l'assemblage dans le graphe (`scoring_node`, #28) suivent.
+Issue #11 — squelette. **Les 3 couches (règles #24, LLM #25, embeddings #26) et
+l'agrégation/persistance (#27) sont implémentées ci-dessous.** Seul l'assemblage
+dans le graphe (`scoring_node`, #28) reste à câbler.
 
 Rappels (CLAUDE.md règles #3/#4/#5/#6) :
 - **Aucune valeur métier codée en dur** : NAF, effectif, mots-clés viennent tous de
@@ -29,7 +29,8 @@ from agents.nettoyage_agent import _matche_exclusion
 from config.settings import get_settings
 from models.criteres import CriteresCiblage
 from models.prospect import Prospect
-from utils.db import upsert_prospect_embedding
+from models.score import ScoreResult
+from utils.db import save_score, upsert_prospect_embedding
 from utils.embeddings import get_embedding
 
 logger = logging.getLogger(__name__)
@@ -307,8 +308,111 @@ async def _score_embedding(
     return cosinus
 
 
+# --- Agrégation + persistance (#27) -----------------------------------------
+# Combine les 3 couches en un score final pondéré (poids PAR CAMPAGNE), en déduit
+# le statut, et historise via `save_score`. Le calcul est pur et testable hors ligne.
+
+# Poids par défaut = ceux du DEFAULT SQL de `campagnes.config_scoring`. Utilisés
+# seulement en repli quand la campagne n'a pas (ou plus) de config — jamais une
+# valeur métier codée en dur (règle #2) : la config campagne prime toujours.
+_POIDS_DEFAUT = {"poids_regles": 0.35, "poids_llm": 0.45, "poids_embedding": 0.20}
+
+# Seuils de statut (SCORING.md, critère d'acceptance #27) — respectés à l'unité près.
+_SEUIL_QUALIFIE = 60
+_SEUIL_INVALIDE = 30
+
+
+def _statut_pour_score(score_final: int) -> str:
+    """`qualifie` si ≥ 60, `invalide` si < 30, `nouveau` sinon (bornes exactes)."""
+    if score_final >= _SEUIL_QUALIFIE:
+        return "qualifie"
+    if score_final < _SEUIL_INVALIDE:
+        return "invalide"
+    return "nouveau"
+
+
+def _agreger(
+    score_regles: int,
+    score_llm: int,
+    score_embedding: float,
+    poids: dict | None = None,
+) -> tuple[int, str]:
+    """Score final 0-100 + statut, à partir des 3 sous-scores. Pur, déterministe.
+
+    `score_regles`/`score_llm` sont déjà sur 0-100 ; `score_embedding` est un COSINUS
+    0-1 (cf. `ScoreResult.score_embedding`) — le ×100 n'a lieu QUE dans cette somme
+    pondérée, jamais dans ce qui est persisté en base. Poids manquants → repli sur
+    `_POIDS_DEFAUT`, clé par clé (une config partielle reste valide)."""
+    p = poids or {}
+    w_regles = p.get("poids_regles", _POIDS_DEFAUT["poids_regles"])
+    w_llm = p.get("poids_llm", _POIDS_DEFAUT["poids_llm"])
+    w_embedding = p.get("poids_embedding", _POIDS_DEFAUT["poids_embedding"])
+
+    brut = w_regles * score_regles + w_llm * score_llm + w_embedding * (score_embedding * 100)
+    score_final = max(0, min(100, round(brut)))
+    return score_final, _statut_pour_score(score_final)
+
+
+async def agreger_et_sauvegarder(
+    prospect_id: str,
+    score_regles: int,
+    llm: dict,
+    score_embedding: float,
+    config_scoring: dict | None = None,
+    *,
+    prompt_version: str | None = None,
+    modele_llm: str | None = None,
+) -> ScoreResult:
+    """Agrège les 3 couches, persiste (historique `scores` + scores/statut courants
+    du prospect + compteur qualifiés), et renvoie le `ScoreResult`.
+
+    `llm` = dict renvoyé par `_score_llm` (`score`, `justification`, `signaux_*`,
+    `priorite`). `config_scoring` = poids PAR CAMPAGNE, déjà chargés dans
+    `EtatAgent["config_scoring"]` par `init_campagne` (#16) depuis
+    `campagnes.config_scoring` — passés ici par le node (#28), pas re-lus en base ;
+    repli sur `_POIDS_DEFAUT` si None/incomplet. NB : le vecteur du prospect est déjà
+    persisté dans Qdrant par `_score_embedding` (#26) — pas de `qdrant_client` ici
+    (contrairement au brouillon de l'issue). `save_score` pose le `statut` et
+    incrémente `prospects_qualifies` (garde de transition)."""
+    poids = config_scoring
+    score_llm = llm["score"]
+    score_final, statut = _agreger(score_regles, score_llm, score_embedding, poids)
+
+    resultat = ScoreResult(
+        score_regles=score_regles,
+        score_llm=score_llm,
+        score_embedding=score_embedding,
+        score_final=score_final,
+        justification_llm=llm.get("justification", ""),
+        signaux_positifs=list(llm.get("signaux_positifs", [])),
+        signaux_negatifs=list(llm.get("signaux_negatifs", [])),
+        priorite=llm.get("priorite", "moyenne"),
+    )
+
+    await save_score(
+        prospect_id,
+        {
+            "score_regles": score_regles,
+            "score_llm": score_llm,
+            "score_embedding": score_embedding,  # cosinus 0-1 — JAMAIS ×100 en base
+            "score_final": score_final,
+            "statut": statut,
+            "justification_llm": resultat.justification_llm,
+            "prompt_version": prompt_version,
+            "modele_llm": modele_llm,
+            "details": {
+                "signaux_positifs": resultat.signaux_positifs,
+                "signaux_negatifs": resultat.signaux_negatifs,
+                "priorite": resultat.priorite,
+                "poids": poids or _POIDS_DEFAUT,
+            },
+        },
+    )
+    return resultat
+
+
 # --- Node d'assemblage (#28) — stub -----------------------------------------
 async def scoring_node(state: dict) -> dict:
-    """STUB — node de scoring hybride. Couches 2/3 + agrégation + câblage à venir
-    (#25, #26, #27, #28). La couche règles ci-dessus est prête et testée (#24)."""
+    """STUB — node de scoring hybride. Couches + agrégation prêtes ; l'assemblage
+    dans le graphe (câblage `_score_*` → `agreger_et_sauvegarder`) reste #28."""
     raise NotImplementedError("scoring_node non assemblé — voir #28.")

--- a/docs/SCORING.md
+++ b/docs/SCORING.md
@@ -397,61 +397,69 @@ osm_tags        = ['shop=car_repair']
 Fichier : `agents/scoring_agent.py` → agrégation dans le node, puis `utils.db.save_score`.
 
 ```python
-from config.settings import get_settings
 from models.score import ScoreResult
 
+# Repli seulement : la config campagne (state["config_scoring"]) prime toujours.
+_POIDS_DEFAUT = {"poids_regles": 0.35, "poids_llm": 0.45, "poids_embedding": 0.20}
 
-def _statut(score_final: int) -> str:
+
+def _statut_pour_score(score_final: int) -> str:
     return "qualifie" if score_final >= 60 else "invalide" if score_final < 30 else "nouveau"
 
 
-async def agreger_et_sauvegarder(prospect_id: str, result: ScoreResult,
-                                 config_scoring: dict | None) -> str:
-    cfg = config_scoring or {}
-    w_r = cfg.get("poids_regles", 0.35)
-    w_l = cfg.get("poids_llm", 0.45)
-    w_e = cfg.get("poids_embedding", 0.20)
-
+def _agreger(score_regles: int, score_llm: int, score_embedding: float,
+             poids: dict | None = None) -> tuple[int, str]:
+    p = poids or {}
+    w_r = p.get("poids_regles", 0.35)
+    w_l = p.get("poids_llm", 0.45)
+    w_e = p.get("poids_embedding", 0.20)
     score_final = round(
-        w_r * result.score_regles
-        + w_l * result.score_llm
-        + w_e * (result.score_embedding * 100)   # ⟳ ×100 ICI seulement (cosinus 0-1 → 0-100)
+        w_r * score_regles + w_l * score_llm + w_e * (score_embedding * 100)  # ×100 ICI seulement
     )
     score_final = max(0, min(100, score_final))
-    statut = _statut(score_final)
+    return score_final, _statut_pour_score(score_final)
 
-    settings = get_settings()
+
+async def agreger_et_sauvegarder(prospect_id: str, score_regles: int, llm: dict,
+                                 score_embedding: float, config_scoring: dict | None = None,
+                                 *, prompt_version: str | None = None,
+                                 modele_llm: str | None = None) -> ScoreResult:
+    # config_scoring vient de state["config_scoring"] (chargé 1×/campagne par #16) —
+    # passé par le node #28, PAS relu en base par prospect.
+    score_final, statut = _agreger(score_regles, llm["score"], score_embedding, config_scoring)
+    resultat = ScoreResult(
+        score_regles=score_regles, score_llm=llm["score"], score_embedding=score_embedding,
+        score_final=score_final, justification_llm=llm.get("justification", ""),
+        signaux_positifs=list(llm.get("signaux_positifs", [])),
+        signaux_negatifs=list(llm.get("signaux_negatifs", [])),
+        priorite=llm.get("priorite", "moyenne"),
+    )
     await save_score(prospect_id, {
-        "score_regles": result.score_regles,
-        "score_llm": result.score_llm,
-        "score_embedding": result.score_embedding,   # cosinus 0-1 (colonne dédiée)
-        "score_final": score_final,
-        "justification_llm": result.justification_llm,
-        "prompt_version": "v2.0-generique",
-        "modele_llm": settings.claude_scoring_model,  # ⟳ colonne `scores.modele_llm`
-        "details": {                                  # ⟳ colonne `scores.details` (JSONB)
-            "signaux_positifs": result.signaux_positifs,
-            "signaux_negatifs": result.signaux_negatifs,
-            "priorite": result.priorite,
-            "statut": statut,
-        },
+        "score_regles": score_regles, "score_llm": llm["score"],
+        "score_embedding": score_embedding,   # cosinus 0-1 (colonne dédiée — jamais ×100)
+        "score_final": score_final, "statut": statut,
+        "justification_llm": resultat.justification_llm,
+        "prompt_version": prompt_version, "modele_llm": modele_llm,
+        "details": {"signaux_positifs": resultat.signaux_positifs,
+                    "signaux_negatifs": resultat.signaux_negatifs,
+                    "priorite": resultat.priorite, "poids": config_scoring or _POIDS_DEFAUT},
     })
-    return statut
+    return resultat
 ```
 
-> **⟳ dérive corrigée — fonctions inexistantes.** `update_prospect_score(...)` et
-> `increment_campagne_kpi(...)` **n'existent pas** dans `utils/db.py`. À la place :
+> **Livré en #27.** `update_prospect_score(...)` / `increment_campagne_kpi(...)` n'existent
+> toujours pas — tout passe par `save_score` :
 >
 > - **`save_score(prospect_id, score_data)`** insère dans `scores` **ET** met à jour
 >   `prospects.score_{regles,llm,embedding,final}` dans une transaction. Champs acceptés :
->   `score_regles, score_llm, score_embedding, score_final, justification_llm,
+>   `score_regles, score_llm, score_embedding, score_final, statut, justification_llm,
 >   prompt_version, modele_llm, details`.
-> - **⚠️ `save_score` ne pose PAS le `statut`** aujourd'hui (l'UPDATE ne touche que les
->   `score_*`). **À étendre en #27** : ajouter un paramètre `statut` et la colonne à l'UPDATE
->   `prospects` (ou faire un UPDATE séparé). En attendant, le `statut` est transporté dans
->   `details` (traçabilité) et renvoyé par la fonction.
-> - Le compteur de qualifiés vit dans `state["qualifies"]` (incrémenté dans le node) — il n'y
->   a **pas** d'`increment_campagne_kpi`.
+> - ✅ **`save_score` pose désormais le `statut`** (`COALESCE`) **et incrémente
+>   `campagnes.prospects_qualifies`** — mais UNIQUEMENT sur une transition vers `qualifie`
+>   (ancien statut ≠ 'qualifie', ligne verrouillée `FOR UPDATE`) : l'historique `scores`
+>   autorise les re-scorings, un simple +1 par scoring double-compterait.
+> - Le compteur DB `campagnes.prospects_qualifies` est distinct du compteur in-run
+>   `state["qualifies"]` (incrémenté par le node #28) ; il n'y a pas d'`increment_campagne_kpi`.
 
 ---
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -481,3 +481,117 @@ def test_score_llm_repli_sans_bloc_texte():
     client = _FakeClient(resp=SimpleNamespace(content=[]))   # next(...) -> StopIteration
     r = asyncio.run(_score_llm(client, "s", "u", score_regles_fallback=55))
     assert r["score"] == 55
+
+
+# --- Agrégation (#27) : _statut_pour_score / _agreger (purs) -----------------
+
+@pytest.mark.parametrize(
+    "score_final, attendu",
+    [
+        (100, "qualifie"),
+        (60, "qualifie"),   # borne exacte ≥ 60
+        (59, "nouveau"),
+        (30, "nouveau"),    # borne exacte : 30 n'est PAS invalide
+        (29, "invalide"),   # < 30
+        (0, "invalide"),
+    ],
+)
+def test_statut_pour_score_seuils_exacts(score_final, attendu):
+    assert sa._statut_pour_score(score_final) == attendu
+
+
+def test_agreger_poids_defaut_combinaison_connue():
+    # 0.35*60 + 0.45*80 + 0.20*(0.5*100) = 21 + 36 + 10 = 67
+    assert sa._agreger(60, 80, 0.5) == (67, "qualifie")
+
+
+def test_agreger_embedding_x100_pas_x1():
+    # score_embedding est un cosinus 0-1 ; il DOIT compter ×100 dans la somme.
+    # emb=1.0 seul (poids défaut 0.20) => contribue 20 pts, pas 0.2.
+    assert sa._agreger(0, 0, 1.0) == (20, "invalide")
+    assert sa._agreger(0, 0, 0.0) == (0, "invalide")
+
+
+def test_agreger_borne_haute_a_100():
+    # Poids volontairement > 1 au total => brut dépasse 100 => clampé à 100.
+    poids = {"poids_regles": 1.0, "poids_llm": 1.0, "poids_embedding": 1.0}
+    assert sa._agreger(100, 100, 1.0, poids) == (100, "qualifie")
+
+
+def test_agreger_poids_campagne_priment():
+    # Config campagne 100% règles : seul score_regles compte.
+    poids = {"poids_regles": 1.0, "poids_llm": 0.0, "poids_embedding": 0.0}
+    assert sa._agreger(90, 10, 0.1, poids) == (90, "qualifie")
+
+
+def test_agreger_poids_partiel_repli_par_cle():
+    # Config incomplète (llm seul) : regles/embedding retombent sur le défaut.
+    # 0.35*40 + 1.0*0 + 0.20*(1.0*100) = 14 + 0 + 20 = 34 -> nouveau
+    assert sa._agreger(40, 0, 1.0, {"poids_llm": 1.0}) == (34, "nouveau")
+
+
+def test_agreger_dict_vide_equivaut_au_defaut():
+    assert sa._agreger(60, 80, 0.5, {}) == sa._agreger(60, 80, 0.5, None)
+
+
+# --- Agrégation (#27) : agreger_et_sauvegarder (I/O monkeypatchées) ----------
+
+def _fake_llm(score=88):
+    return {
+        "score": score,
+        "justification": "match ICP",
+        "signaux_positifs": ["site web"],
+        "signaux_negatifs": [],
+        "priorite": "haute",
+    }
+
+
+def _patch_save(monkeypatch):
+    """Monkeypatch save_score (capture le score_data). `config_scoring` est un
+    paramètre (issu de `state`), plus une lecture BDD — rien d'autre à patcher."""
+    capture = {}
+
+    async def _fake_save(prospect_id, score_data):
+        capture["prospect_id"] = prospect_id
+        capture["score_data"] = score_data
+
+    monkeypatch.setattr(sa, "save_score", _fake_save)
+    return capture
+
+
+def test_agreger_et_sauvegarder_persiste_et_mappe(monkeypatch):
+    cap = _patch_save(monkeypatch)
+    res = asyncio.run(
+        sa.agreger_et_sauvegarder(
+            "pid-1", score_regles=90, llm=_fake_llm(10), score_embedding=0.9,
+            config_scoring={"poids_regles": 1.0, "poids_llm": 0.0, "poids_embedding": 0.0},
+            prompt_version="v1", modele_llm="claude-haiku-4-5",
+        )
+    )
+    # 100% règles -> score_final = 90 -> qualifie ; sortie LLM mappée dans ScoreResult.
+    assert (res.score_final, res.score_regles, res.score_llm) == (90, 90, 10)
+    assert res.priorite == "haute" and res.signaux_positifs == ["site web"]
+
+    sd = cap["score_data"]
+    assert cap["prospect_id"] == "pid-1"
+    assert sd["statut"] == "qualifie"
+    assert sd["score_final"] == 90
+    assert sd["modele_llm"] == "claude-haiku-4-5" and sd["prompt_version"] == "v1"
+    # signaux + priorité + poids historisés dans details (audit #32).
+    assert sd["details"]["priorite"] == "haute"
+    assert sd["details"]["poids"] == {"poids_regles": 1.0, "poids_llm": 0.0, "poids_embedding": 0.0}
+
+
+def test_agreger_et_sauvegarder_embedding_reste_cosinus(monkeypatch):
+    # Le ×100 ne doit vivre QUE dans score_final, jamais dans la colonne score_embedding.
+    cap = _patch_save(monkeypatch)
+    res = asyncio.run(
+        sa.agreger_et_sauvegarder(  # config_scoring omis -> None -> poids par défaut
+            "pid-2", score_regles=0, llm=_fake_llm(0), score_embedding=0.5
+        )
+    )
+    sd = cap["score_data"]
+    assert sd["score_embedding"] == 0.5          # cosinus brut 0-1 persisté
+    assert res.score_embedding == 0.5
+    # 0.20 * (0.5*100) = 10 -> score_final 10, statut invalide (poids défaut, repli None).
+    assert sd["score_final"] == 10 and sd["statut"] == "invalide"

--- a/utils/db.py
+++ b/utils/db.py
@@ -150,7 +150,14 @@ async def upsert_prospect(data: dict) -> str:
 
 async def save_score(prospect_id: str, score_data: dict) -> None:
     """Historise un scoring (table `scores`) et met à jour les scores courants
-    du prospect, dans une même transaction."""
+    du prospect, dans une même transaction.
+
+    Si `score_data["statut"]` est fourni (agrégation #27), met aussi à jour
+    `prospects.statut` ET incrémente `campagnes.prospects_qualifies` — mais
+    UNIQUEMENT sur une transition vers `qualifie` (ancien statut ≠ 'qualifie').
+    L'historique `scores` autorise plusieurs scorings par prospect ; sans ce
+    garde de transition, un re-scoring double-compterait les qualifiés."""
+    statut = score_data.get("statut")
     pool = await get_pg_pool()
     async with pool.acquire() as conn, conn.transaction():
         await conn.execute(
@@ -170,13 +177,23 @@ async def save_score(prospect_id: str, score_data: dict) -> None:
             score_data.get("modele_llm"),
             score_data.get("details", {}),
         )
+        # Ancien statut + campagne (verrouillés) — lus AVANT l'UPDATE pour décider
+        # de la transition. Requête évitée dans le chemin historique sans statut.
+        ancien = None
+        if statut is not None:
+            ancien = await conn.fetchrow(
+                "SELECT statut, campagne_id FROM prospects WHERE id = $1 FOR UPDATE;",
+                prospect_id,
+            )
         await conn.execute(
             """
             UPDATE prospects SET
                 score_regles    = COALESCE($2, score_regles),
                 score_llm       = COALESCE($3, score_llm),
                 score_embedding = COALESCE($4, score_embedding),
-                score_final     = COALESCE($5, score_final)
+                score_final     = COALESCE($5, score_final),
+                statut          = COALESCE($6, statut),
+                updated_at      = NOW()
             WHERE id = $1;
             """,
             prospect_id,
@@ -184,7 +201,14 @@ async def save_score(prospect_id: str, score_data: dict) -> None:
             score_data.get("score_llm"),
             score_data.get("score_embedding"),
             score_data.get("score_final"),
+            statut,
         )
+        if statut == "qualifie" and ancien is not None and ancien["statut"] != "qualifie":
+            await conn.execute(
+                "UPDATE campagnes SET prospects_qualifies = prospects_qualifies + 1 "
+                "WHERE id = $1;",
+                ancien["campagne_id"],
+            )
 
 
 async def get_file_appel(limit: int = 100) -> list[dict]:


### PR DESCRIPTION
## #27 — Agrégation score final + persistance historique

Branché sur un `main` à jour (`18027c3`) : les 3 couches (#24 règles, #25 LLM, #26 embeddings) y sont déjà. Cette PR ajoute la couche d'agrégation + la persistance.

### Contenu
- **`agents/scoring_agent.py`**
  - `_agreger(score_regles, score_llm, score_embedding, poids)` — **pur** : somme pondérée `w_r·regles + w_l·llm + w_e·(embedding×100)`, `round`, clamp `[0,100]`, puis statut.
  - `_statut_pour_score` — `qualifie` si ≥ 60, `invalide` si < 30, `nouveau` sinon (bornes exactes).
  - `agreger_et_sauvegarder(...) -> ScoreResult` — mappe la sortie `_score_llm` vers `ScoreResult` et persiste via `save_score`.
- **`utils/db.py`** — `save_score` étendu : pose `prospects.statut` (`COALESCE`) et incrémente `campagnes.prospects_qualifies`.
- **`docs/SCORING.md`** — section agrégation réalignée sur la signature livrée.
- **`tests/test_scoring.py`** — 14 tests (voir plus bas).

### Formule (issue + SCORING.md)
```
score_final = round(0.35·regles + 0.45·llm + 0.20·(embedding×100)) ; clampé [0,100]
statut      = qualifie (≥60) | invalide (<30) | nouveau
```
Poids **par campagne** (`campagnes.config_scoring`, défaut 0.35/0.45/0.20), jamais codés en dur (règle #2).

### 3 décisions de conception
1. **×100 uniquement dans `score_final`.** `prospects.score_embedding` / `scores.score_embedding` sont `REAL CHECK BETWEEN 0 AND 1` → on persiste le **cosinus brut 0-1**, le ×100 ne vit que dans la somme pondérée (test dédié).
2. **`qdrant_client` retiré** de la signature du brouillon de l'issue : #26 persiste déjà le vecteur prospect dans Qdrant à l'intérieur de `_score_embedding` — le paramètre était redondant.
3. **`config_scoring` vient de `state`, pas d'une relecture BDD.** `init_campagne` (#16) charge déjà `campagnes.config_scoring` dans `EtatAgent["config_scoring"]` 1×/campagne (`graph/state.py`, `graph/workflow.py:165`). L'agrégation reçoit donc les poids en paramètre (passés par le node #28) au lieu de refaire une requête par prospect — dérive doc↔code de SCORING.md corrigée dans les deux sens.

### Compteur `prospects_qualifies` — garde de transition
L'historique `scores` autorise **plusieurs scorings par prospect** ; incrémenter à chaque `save` double-compterait. `save_score` lit l'ancien statut (`FOR UPDATE`) et n'incrémente **que** sur `ancien != 'qualifie'` → `'qualifie'`.

### Tests — 269 → 283 (réconcilié), `-m "not integration"`
- `_statut_pour_score` : seuils exacts 100/60/59/30/29/0.
- `_agreger` : combinaison connue, **×100 vs ×1** de l'embedding, clamp haut, poids campagne prioritaires, config partielle (repli par clé), dict vide ≡ défaut.
- `agreger_et_sauvegarder` : mapping LLM→`ScoreResult` + `score_data` (statut/details/poids), et **`score_embedding` persisté en 0-1** (jamais ×100).
- ⚠️ La garde de transition SQL (`FOR UPDATE` + `+1`) relève d'un test `@integration` (vraie PG) — à couvrir en #31.

### Suite
#28 câble `scoring_node` : `_score_regles`/`_score_llm`/`_score_embedding` → `agreger_et_sauvegarder(..., config_scoring=state["config_scoring"])`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
