### PR TITLE
feat(#28): assemblage du pipeline (scoring_node + run) — chaîne manuelle

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -27,10 +27,11 @@ from jinja2 import Environment, FileSystemLoader
 # règle #4) a une seule source de vérité, partagée avec le nettoyage (#19).
 from agents.nettoyage_agent import _matche_exclusion
 from config.settings import get_settings
+from graph.state import EtatAgent
 from models.criteres import CriteresCiblage
 from models.prospect import Prospect
 from models.score import ScoreResult
-from utils.db import save_score, upsert_prospect_embedding
+from utils.db import save_score, upsert_prospect, upsert_prospect_embedding
 from utils.embeddings import get_embedding
 
 logger = logging.getLogger(__name__)
@@ -411,8 +412,56 @@ async def agreger_et_sauvegarder(
     return resultat
 
 
-# --- Node d'assemblage (#28) — stub -----------------------------------------
-async def scoring_node(state: dict) -> dict:
-    """STUB — node de scoring hybride. Couches + agrégation prêtes ; l'assemblage
-    dans le graphe (câblage `_score_*` → `agreger_et_sauvegarder`) reste #28."""
-    raise NotImplementedError("scoring_node non assemblé — voir #28.")
+# --- Node de scoring hybride (#28) ------------------------------------------
+async def scoring_node(state: EtatAgent) -> EtatAgent:
+    """Score + persiste chaque prospect de `state["prospects"]`.
+
+    Par prospect : `upsert_prospect` (→ id) → règles (#24) + LLM (#25) + embedding
+    (#26) → `agreger_et_sauvegarder` (#27, persiste scores/statut + compteur BDD).
+    Incrémente le compteur in-run `state["qualifies"]`.
+
+    Robustesse (#28) :
+    - **Panne Claude** : `_score_llm` bascule seul sur le score règles
+      (score_final = 0.80·règles + 0.20·embedding, cf. SCORING.md) — pas d'arrêt.
+    - **Échec d'UN prospect** (upsert/embedding/persistance) : loggé + ajouté à
+      `state["erreurs"]`, on passe au suivant — un prospect ne fait pas échouer la campagne.
+
+    La persistance est câblée ICI plutôt que dans un node « sauvegarder » distinct :
+    `save_score` et `_score_embedding` (upsert du vecteur Qdrant) ont besoin de l'`id`
+    retourné par `upsert_prospect`, indisponible avant le scoring."""
+    prospects = state.get("prospects") or []
+    state.setdefault("erreurs", [])
+    state.setdefault("qualifies", 0)
+    if not prospects:
+        return state
+
+    criteres = state["criteres"]
+    icp_embedding = state.get("icp_embedding")
+    config_scoring = state.get("config_scoring")
+    settings = get_settings()
+
+    # Rendu 1×/campagne (system = candidat au cache) ; un seul client Claude pour le lot.
+    system_rendu = rendre_system(criteres)
+    async with anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key) as client:
+        for prospect in prospects:
+            try:
+                prospect_id = await upsert_prospect(prospect.to_db_dict())
+                score_regles = _score_regles(prospect, criteres)
+                user_rendu = rendre_user(prospect)
+                llm = await _score_llm(
+                    client, system_rendu, user_rendu, score_regles_fallback=score_regles
+                )
+                score_embedding = await _score_embedding(prospect, icp_embedding, prospect_id)
+                resultat = await agreger_et_sauvegarder(
+                    prospect_id, score_regles, llm, score_embedding, config_scoring,
+                    modele_llm=settings.claude_scoring_model,
+                )
+                if _statut_pour_score(resultat.score_final) == "qualifie":
+                    state["qualifies"] += 1
+            except Exception as exc:  # un prospect en échec ne casse pas la campagne (#28)
+                logger.warning(
+                    "Scoring échoué pour '%s' (%s) — prospect ignoré.",
+                    prospect.nom_entreprise, exc,
+                )
+                state["erreurs"].append(f"scoring:{prospect.nom_entreprise}:{exc}")
+    return state

--- a/graph/workflow.py
+++ b/graph/workflow.py
@@ -12,11 +12,18 @@ Règle #8 : async partout (asyncpg via `utils.db`).
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
+from agents.enrichissement_agent import enrichissement_node
+from agents.nettoyage_agent import nettoyage_node
+from agents.scoring_agent import scoring_node
+from agents.sirene_agent import sirene_node
 from graph.state import EtatAgent
 from models.criteres import CriteresCiblage
 from utils import db
+
+logger = logging.getLogger(__name__)
 
 
 # --- Exceptions (AC2 : erreurs explicites, fail fast) ----------------------
@@ -166,13 +173,53 @@ async def init_campagne(etat: EtatAgent) -> EtatAgent:
     return etat
 
 
-# --- Assemblage du graphe (issue #28 — STUB) -------------------------------
+# --- Assemblage du pipeline (issue #28) ------------------------------------
 
-def build_graph():  # type: ignore[no-untyped-def]
-    """STUB — construit le StateGraph LangChain. À implémenter (#28)."""
-    raise NotImplementedError("graph/workflow.build_graph non implémenté — voir #28.")
+# Les 6 nodes dans l'ordre. Chaîne manuelle (pas de dépendance LangGraph — cf. #28
+# et la note de prep) : chaque node reste un `async (state) -> state`, contrat
+# compatible avec un futur `StateGraph` si on décide d'ajouter LangGraph.
+# `prerequis=True` : un échec rend la suite vide de sens (pas de contexte / pas de
+# prospects) → on stoppe proprement. Sinon on logge et on continue (pipeline partiel).
+_PIPELINE: tuple[tuple[str, object, bool], ...] = (
+    ("init_campagne", init_campagne, True),
+    ("fetch_sirene", sirene_node, True),
+    ("enrichir", enrichissement_node, False),
+    ("nettoyer", nettoyage_node, False),
+    ("scorer", scoring_node, False),
+)
+
+
+def build_graph() -> tuple[tuple[str, object, bool], ...]:
+    """Retourne la description ordonnée du pipeline (nodes async `(state) -> state`).
+
+    Chaîne manuelle, sans dépendance graphe. Point d'extension unique si l'équipe
+    ajoute LangGraph plus tard : mapper `_PIPELINE` sur un `StateGraph`. `run`
+    exécute cette description."""
+    return _PIPELINE
 
 
 async def run(state: EtatAgent) -> EtatAgent:
-    """STUB — exécute le graphe complet pour une campagne. À implémenter (#28/#29)."""
-    raise NotImplementedError("graph/workflow.run non implémenté — voir #28.")
+    """Exécute le pipeline complet pour une campagne, nodes en séquence (#28).
+
+    Gestion d'erreurs par node : chaque échec est loggé et poussé dans
+    `state["erreurs"]`. Un node **prérequis** en échec (`init_campagne`,
+    `fetch_sirene`) arrête le pipeline — inutile de continuer sans contexte ni
+    prospects. Les autres nodes n'arrêtent pas la campagne (résultat partiel > rien).
+    La panne Claude est absorbée dans `scoring_node` (repli règles), pas ici.
+
+    `state` doit contenir `campagne_id`. Retourne l'état final (avec `qualifies`,
+    `erreurs`). La fermeture du pool PG / client Qdrant est du ressort de
+    l'orchestrateur appelant (`main.py`, #29), pas de `run`."""
+    state.setdefault("erreurs", [])
+    state.setdefault("collectes", 0)
+    state.setdefault("qualifies", 0)
+    for nom, node, prerequis in _PIPELINE:
+        try:
+            state = await node(state)  # type: ignore[operator]
+        except Exception as exc:
+            logger.exception("Node '%s' en échec : %s", nom, exc)
+            state["erreurs"].append(f"{nom}:{exc}")
+            if prerequis:
+                logger.error("Node prérequis '%s' échoué — arrêt du pipeline.", nom)
+                break
+    return state

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -227,8 +227,6 @@ def test_regles_effectif_estime_pas_le_libelle():
 
 
 # --- Node d'assemblage (#28) — reste un stub tant que le graphe n'est pas câblé ----
-# Conservés depuis #11 : la couche règles est prête (#24) mais `scoring_node` (câblage
-# des 3 couches + agrégation) n'est assemblé qu'en #28.
 def test_scoring_node_is_async_coroutine() -> None:
     """`scoring_node` est bien une coroutine async (règle #8)."""
     from agents.scoring_agent import scoring_node
@@ -236,12 +234,89 @@ def test_scoring_node_is_async_coroutine() -> None:
     assert inspect.iscoroutinefunction(scoring_node)
 
 
-def test_scoring_node_stub_raises_not_implemented() -> None:
-    """Le node lève NotImplementedError tant que #28 ne l'a pas assemblé."""
-    from agents.scoring_agent import scoring_node
+# --- Node de scoring (#28) : I/O + couches monkeypatchées -------------------
 
-    with pytest.raises(NotImplementedError):
-        asyncio.run(scoring_node({"prospects": []}))
+
+class _FakeAsyncClient:
+    """AsyncAnthropic factice — le node l'ouvre en context manager mais _score_llm
+    est monkeypatché, donc le client n'est jamais réellement utilisé."""
+
+    def __init__(self, *a, **k):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _patch_scoring_node(monkeypatch, scores_finaux):
+    """Monkeypatch upsert/couches/agrégation + le client Claude. `scores_finaux` =
+    liste des score_final renvoyés (1 par prospect scoré). Retourne les ids upsertés."""
+    ids = []
+    it = iter(scores_finaux)
+
+    async def _fake_upsert(data):
+        pid = f"id-{len(ids)}"
+        ids.append(pid)
+        return pid
+
+    async def _fake_llm(client, sys, usr, score_regles_fallback):
+        return {"score": 50, "justification": "x", "signaux_positifs": [],
+                "signaux_negatifs": [], "priorite": "moyenne"}
+
+    async def _fake_embedding(prospect, icp, prospect_id=None):
+        return 0.5
+
+    async def _fake_agreger(prospect_id, score_regles, llm, score_embedding,
+                            config_scoring=None, **kw):
+        return sa.ScoreResult(
+            score_regles=score_regles, score_llm=llm["score"],
+            score_embedding=score_embedding, score_final=next(it), priorite="moyenne",
+        )
+
+    monkeypatch.setattr(sa.anthropic, "AsyncAnthropic", _FakeAsyncClient)
+    monkeypatch.setattr(sa, "upsert_prospect", _fake_upsert)
+    monkeypatch.setattr(sa, "_score_llm", _fake_llm)
+    monkeypatch.setattr(sa, "_score_embedding", _fake_embedding)
+    monkeypatch.setattr(sa, "agreger_et_sauvegarder", _fake_agreger)
+    return ids
+
+
+def _state_scoring(prospects):
+    return {"prospects": prospects, "criteres": _criteres(),
+            "icp_embedding": None, "config_scoring": {}}
+
+
+def test_scoring_node_compte_les_qualifies(monkeypatch):
+    ids = _patch_scoring_node(monkeypatch, scores_finaux=[75, 20])  # 1 qualifie, 1 invalide
+    state = _state_scoring([_p("A"), _p("B")])
+    out = asyncio.run(sa.scoring_node(state))
+    assert len(ids) == 2                # un upsert par prospect
+    assert out["qualifies"] == 1        # seuls les >= 60 comptent
+    assert out["erreurs"] == []
+
+
+def test_scoring_node_isole_les_erreurs(monkeypatch):
+    _patch_scoring_node(monkeypatch, scores_finaux=[80])  # 1 seul score consommé (le bon)
+
+    async def _upsert_ko_puis_ok(data):
+        if data["nom_entreprise"] == "KO":
+            raise RuntimeError("upsert boom")
+        return "id-ok"
+
+    monkeypatch.setattr(sa, "upsert_prospect", _upsert_ko_puis_ok)
+    state = _state_scoring([_p("KO"), _p("OK")])
+    out = asyncio.run(sa.scoring_node(state))
+    assert len(out["erreurs"]) == 1 and "KO" in out["erreurs"][0]
+    assert out["qualifies"] == 1        # le prospect OK est bien scoré malgré l'échec du KO
+
+
+def test_scoring_node_sans_prospects_ne_fait_rien(monkeypatch):
+    ids = _patch_scoring_node(monkeypatch, scores_finaux=[])
+    out = asyncio.run(sa.scoring_node({"prospects": [], "criteres": _criteres()}))
+    assert ids == [] and out["qualifies"] == 0
 
 
 # --- Couche 3 : cosinus pur (#26) -------------------------------------------

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,0 +1,65 @@
+"""Tests de l'orchestration du pipeline (#28) — `graph.workflow.run` / `build_graph`.
+
+Purs : on monkeypatche `_PIPELINE` avec des nodes factices (les vrais nodes ont
+leurs propres tests). On vérifie l'ordre d'exécution, l'arrêt sur node prérequis
+et la poursuite sur node non-prérequis, et l'enregistrement des erreurs.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from graph import workflow as wf
+
+
+def _recorder(nom):
+    """Node factice : note son passage dans state['ordre'] et renvoie l'état."""
+    async def _node(state):
+        state.setdefault("ordre", []).append(nom)
+        return state
+    return _node
+
+
+def _boom(nom):
+    async def _node(state):
+        raise RuntimeError(f"{nom} explose")
+    return _node
+
+
+def test_build_graph_expose_les_5_nodes_dans_l_ordre():
+    noms = [nom for nom, _node, _prereq in wf.build_graph()]
+    assert noms == ["init_campagne", "fetch_sirene", "enrichir", "nettoyer", "scorer"]
+
+
+def test_run_execute_les_nodes_en_sequence(monkeypatch):
+    monkeypatch.setattr(wf, "_PIPELINE", (
+        ("a", _recorder("a"), True),
+        ("b", _recorder("b"), True),
+        ("c", _recorder("c"), False),
+    ))
+    out = asyncio.run(wf.run({"campagne_id": "x"}))
+    assert out["ordre"] == ["a", "b", "c"]
+    assert out["erreurs"] == []
+    # run() initialise les compteurs de suivi.
+    assert out["qualifies"] == 0 and out["collectes"] == 0
+
+
+def test_run_arrete_sur_node_prerequis_en_echec(monkeypatch):
+    monkeypatch.setattr(wf, "_PIPELINE", (
+        ("a", _recorder("a"), True),
+        ("b", _boom("b"), True),          # prérequis KO -> stop
+        ("c", _recorder("c"), False),
+    ))
+    out = asyncio.run(wf.run({"campagne_id": "x"}))
+    assert out["ordre"] == ["a"]          # c n'a jamais tourné
+    assert len(out["erreurs"]) == 1 and out["erreurs"][0].startswith("b:")
+
+
+def test_run_continue_apres_node_non_prerequis_en_echec(monkeypatch):
+    monkeypatch.setattr(wf, "_PIPELINE", (
+        ("a", _recorder("a"), True),
+        ("b", _boom("b"), False),         # non prérequis -> on logge et on continue
+        ("c", _recorder("c"), False),
+    ))
+    out = asyncio.run(wf.run({"campagne_id": "x"}))
+    assert out["ordre"] == ["a", "c"]     # c a bien tourné malgré l'échec de b
+    assert len(out["erreurs"]) == 1 and out["erreurs"][0].startswith("b:")


### PR DESCRIPTION
## #28 — Assemblage du pipeline (6 nodes)

Branché sur `main` à jour (`483bf90`) : le cœur scoring #24→#27 y est. Cette PR assemble les nodes en un pipeline exécutable de bout en bout.

### Contenu
- **`agents/scoring_agent.py`** — `scoring_node` réel : par prospect `upsert_prospect`→id → règles (#24) + LLM (#25) + embedding (#26) → `agreger_et_sauvegarder` (#27, persiste scores/statut + compteur). Incrémente `state["qualifies"]`.
- **`graph/workflow.py`** — `run()` exécute les nodes en séquence (chaîne manuelle), `build_graph()` expose le pipeline ordonné.

### Décisions
1. **Chaîne manuelle, pas LangGraph** (décision équipe — LangGraph n'est pas une dépendance du repo). Chaque node reste `async (state) -> state` : contrat compatible avec un futur `StateGraph` si l'équipe l'ajoute (évaluation possible plus tard, non bloquante).
2. **Persistance câblée DANS `scoring_node`**, pas de node « sauvegarder » séparé : `save_score` et l'upsert du vecteur Qdrant ont besoin de l'`id` retourné par `upsert_prospect`, indisponible avant le scoring. Les 6 nodes de l'issue deviennent 5 effectifs.
3. **Gestion d'erreurs par node** : chaque échec est loggé + poussé dans `state["erreurs"]`. `init_campagne`/`fetch_sirene` sont **prérequis** (arrêt si échec — rien à traiter en aval) ; les autres continuent (résultat partiel > rien).
4. **Repli panne Claude** (AC #28) : absorbé par `_score_llm` (repli sur le score règles → `score_final = 0.80·règles + 0.20·embedding`) — pas d'arrêt du pipeline. Isolation par prospect : un prospect en échec ne casse pas la campagne.

### Tests — 289 verts (`-m "not integration"`), +6 vs main
−1 test stub obsolète (`scoring_node` levait `NotImplementedError`), +3 `scoring_node` (comptage qualifiés, isolation d'erreurs, liste vide), +4 `workflow` (ordre, arrêt prérequis, poursuite non-prérequis, `build_graph`).

⚠️ **AC E2E** (100 prospects < 15 min ; panne Claude live) = stack docker requise → non exécutables hors stack ; le repli est prouvé au niveau `_score_llm`. Couverts en esprit par #32 (audit 100 prospects réels) ; test `@integration` E2E à ajouter en #31.

### Suite
#29 (CLI `main.py`) pilote `run()` — déjà développé, empilé sur cette branche, à rebaser sur `main` après fusion de cette PR.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)
