### PR TITLE
feat: pré-passe OSM gratuite dans l'enrichissement (OSM #69)

### DIFF
--- a/agents/enrichissement_agent.py
+++ b/agents/enrichissement_agent.py
@@ -49,6 +49,7 @@ from config.settings import Settings, get_settings
 from graph.state import EtatAgent
 from models.criteres import CriteresCiblage
 from models.prospect import Prospect, _clean_email, _normalize_phone
+from utils.osm import enrichir_par_osm
 
 logger = logging.getLogger(__name__)
 
@@ -380,21 +381,40 @@ async def _enrich_prospect(
 
 # --- Node -------------------------------------------------------------------
 async def enrichissement_node(state: EtatAgent, batch_size: int = BATCH_SIZE) -> EtatAgent:
-    """Enrichit `state['prospects']` en tél/email via la cascade. Batch parallèle."""
+    """Enrichit `state['prospects']` en tél/email. Pré-passe OSM géographique (#69,
+    gratuite) PUIS cascade par prospect pour les contacts encore manquants. Batch parallèle."""
     prospects: list[Prospect] = state.get("prospects", [])
     if not prospects:
         return state
     settings = get_settings()
+    criteres = state.get("criteres")
     semaphore = asyncio.Semaphore(batch_size)
     # Vocabulaire non discriminant de CETTE campagne, dérivé de l'ICP client.
-    generic = generic_tokens(state.get("criteres"))
+    generic = generic_tokens(criteres)
 
     async with httpx.AsyncClient(timeout=20.0) as client:
+        # Pré-passe OSM (#69) : source GRATUITE, une requête Overpass par zone. Remplit
+        # tél/email/site depuis OpenStreetMap AVANT la cascade payante. Inapplicable si
+        # l'ICP n'a pas d'`osm_tags` (no-op). Un échec OSM ne casse pas l'enrichissement.
+        osm_tags = list(getattr(criteres, "osm_tags", None) or [])
+        if osm_tags:
+            try:
+                stats = await enrichir_par_osm(
+                    prospects, osm_tags, client=client, settings=settings
+                )
+                logger.info("osm : %s", stats)
+            except Exception as exc:  # OSM KO -> la cascade prend le relais
+                logger.warning("osm pré-passe KO : %s", exc)
+
+        # Cascade (Tavily/Crawl4AI/DDG) UNIQUEMENT pour les prospects encore incomplets
+        # (tél OU email manquant) — OSM a pu tout résoudre : on économise les appels payants.
+        restants = [p for p in prospects if p.email is None or p.telephone is None]
+
         async def _one(prospect: Prospect) -> None:
             async with semaphore:
                 await _enrich_prospect(prospect, client, settings, generic)
 
-        await asyncio.gather(*(_one(p) for p in prospects))
+        await asyncio.gather(*(_one(p) for p in restants))
 
     with_email = sum(1 for p in prospects if p.email)
     with_phone = sum(1 for p in prospects if p.telephone)

--- a/graph/workflow.py
+++ b/graph/workflow.py
@@ -108,6 +108,7 @@ async def init_campagne(etat: EtatAgent) -> EtatAgent:
                 effectif_min, effectif_max, anciennete_min_ans,
                 exiger_site_web, exiger_email,
                 mots_cles_positifs, mots_cles_negatifs,
+                osm_tags,
                 actif
             FROM criteres_ciblage
             WHERE id = $1;
@@ -135,6 +136,7 @@ async def init_campagne(etat: EtatAgent) -> EtatAgent:
             exiger_email=critere_row["exiger_email"],
             mots_cles_positifs=list(critere_row["mots_cles_positifs"] or []),
             mots_cles_negatifs=list(critere_row["mots_cles_negatifs"] or []),
+            osm_tags=list(critere_row["osm_tags"] or []),
             actif=critere_row["actif"],
         )
 

--- a/tests/test_enrichissement.py
+++ b/tests/test_enrichissement.py
@@ -258,3 +258,51 @@ async def test_tavily_resolver_extracts_when_domain_matches_name():
     assert contacts.emails == ["pro@garagex.fr"]           # essec.edu écarté
     assert contacts.site_web == "http://garagex.fr"
     assert contacts.phones                                 # tél de la page confirmée
+
+
+# --- Pré-passe OSM (#69) : câblée avant la cascade dans enrichissement_node ---
+
+@pytest.mark.asyncio
+async def test_node_osm_prepass_puis_cascade_sur_restants(monkeypatch):
+    """OSM (gratuit) tourne AVANT la cascade ; les prospects qu'OSM résout
+    totalement (tél + email) ne repassent PAS par la cascade payante."""
+    p_osm = _p()       # résolu par OSM -> exclu de la cascade
+    p_reste = _p()     # non résolu -> cascade
+    recu = {}
+
+    async def _fake_osm(prospects, osm_tags, client=None, settings=None):
+        recu["tags"] = osm_tags
+        p_osm.email = "jean@osm-garage.fr"     # OSM remplit tél + email
+        p_osm.telephone = "+33123456789"
+        return {"emails": 1, "telephones": 1}
+
+    vus = []
+
+    async def _resolver(prospect, client, settings, site_web, generic):
+        vus.append(prospect)
+        return None
+
+    monkeypatch.setattr(ea, "enrichir_par_osm", _fake_osm)
+    monkeypatch.setattr(ea, "RESOLVERS", [_resolver])
+
+    crit = CriteresCiblage(nom="x", osm_tags=["amenity=car_repair"])
+    await enrichissement_node({"prospects": [p_osm, p_reste], "criteres": crit}, batch_size=2)
+
+    assert recu["tags"] == ["amenity=car_repair"]   # pré-passe OSM appelée avec les tags ICP
+    assert vus == [p_reste]                          # cascade UNIQUEMENT sur le restant
+
+
+@pytest.mark.asyncio
+async def test_node_sans_osm_tags_pas_de_prepass(monkeypatch):
+    """ICP sans osm_tags -> pré-passe OSM court-circuitée (source inapplicable)."""
+    called = {"osm": False}
+
+    async def _fake_osm(*a, **k):
+        called["osm"] = True
+        return {}
+
+    monkeypatch.setattr(ea, "enrichir_par_osm", _fake_osm)
+    monkeypatch.setattr(ea, "RESOLVERS", [])   # cascade vide
+    crit = CriteresCiblage(nom="x")            # pas d'osm_tags
+    await enrichissement_node({"prospects": [_p()], "criteres": crit})
+    assert called["osm"] is False

--- a/tests/test_init_campagne.py
+++ b/tests/test_init_campagne.py
@@ -77,6 +77,7 @@ def _fake_critere_row(*, critere_id: str = CRITERE_ID) -> dict:
         "exiger_email": False,
         "mots_cles_positifs": ["qualite", "service"],
         "mots_cles_negatifs": ["exclusion1", "exclusion2"],
+        "osm_tags": ["amenity=car_repair", "shop=car_repair"],
         "actif": True,
     }
 
@@ -210,6 +211,8 @@ async def test_ac1_unit_charge_tous_les_criteres() -> None:
     assert crit.exiger_email is False
     assert crit.mots_cles_positifs == ["qualite", "service"]
     assert crit.mots_cles_negatifs == ["exclusion1", "exclusion2"]
+    # osm_tags chargés depuis criteres_ciblage → alimentent la pré-passe OSM (#69).
+    assert crit.osm_tags == ["amenity=car_repair", "shop=car_repair"]
     # ICP embedding : le VECTEUR est résolu depuis Qdrant via le qdrant_point_id.
     mock_get_icp.assert_awaited_once_with(icp_point_id)
     assert etat["icp_embedding"] == fake_vecteur


### PR DESCRIPTION
## Pré-passe OSM gratuite dans le pipeline d'enrichissement (OSM #69)

Branché sur `main` (`483bf90`). **Disjoint du stack #28/#29** : ne touche ni `scoring_node` ni `run` ; la modif d'`init_campagne` est dans une région distincte de celle de #29 (auto-merge). Cette PR peut donc fusionner **indépendamment**.

### Motivation
`utils/osm.py` (`enrichir_par_osm` / `interroger_overpass` / `geocoder_ban`) était implémenté mais **branché à rien** (Gap 3). Mesure Sprint 2 : OSM gratuit ≈ **30 % email / 32 % tél** sur les commerces locaux — une source à activer avant les résolveurs payants.

### Contenu
- **`agents/enrichissement_agent.py`** — `enrichissement_node` fait une **pré-passe OSM** (source gratuite, **une requête Overpass par zone géographique**) AVANT la cascade payante. La cascade (Tavily / Crawl4AI / DDG) ne tourne ensuite **que sur les prospects encore incomplets** (tél OU email manquant) → économise les appels payants pour ceux qu'OSM a résolus. Un échec OSM ne casse pas l'enrichissement (repli cascade).
- **`graph/workflow.py`** — `init_campagne` charge désormais `criteres_ciblage.osm_tags` (SELECT + `CriteresCiblage`). Sans ça la pré-passe serait inerte (`osm_tags` vide = source inapplicable).

### Pourquoi OSM en pré-passe batch, pas dans la cascade
`enrichir_par_osm` est **batch par nature** : géocode le lot (BAN), groupe par zone, **une** requête Overpass par zone (cache + rate-limit `OVERPASS_MIN_INTERVAL_S`). En faire un résolveur par-prospect = une requête Overpass **par prospect** → rate-limit assuré. D'où la pré-passe groupée.

### Tests — 283 → 285 verts (`-m "not integration"`)
- `enrichissement` : pré-passe OSM appelée avec les `osm_tags` de l'ICP + cascade **uniquement** sur les restants ; no-op si l'ICP n'a pas d'`osm_tags`.
- `init_campagne` : `osm_tags` chargés depuis `criteres_ciblage`.

### Activation
La pré-passe ne s'active que si l'ICP du client définit des `osm_tags` (ex. `amenity=car_repair` pour les garages). ICP sans `osm_tags` → OSM no-op, cascade seule (comportement inchangé).

### Mode ad hoc (#29)
Le CLI ad hoc synthétise un ICP sans `osm_tags` → OSM y est no-op ; un flag `--osm-tags` serait un ajout naturel côté #29 (hors périmètre ici).

Refs #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
