### PR TITLE
feat(#29): CLI main.py (argparse) — pilote le pipeline, 3 modes + dry-run

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -428,7 +428,11 @@ async def scoring_node(state: EtatAgent) -> EtatAgent:
 
     La persistance est câblée ICI plutôt que dans un node « sauvegarder » distinct :
     `save_score` et `_score_embedding` (upsert du vecteur Qdrant) ont besoin de l'`id`
-    retourné par `upsert_prospect`, indisponible avant le scoring."""
+    retourné par `upsert_prospect`, indisponible avant le scoring.
+
+    `state["dry_run"]` (CLI #29) : scoring calculé en mémoire (règles + LLM + embedding),
+    **aucune écriture** — pas d'`upsert_prospect`, pas de `save_score`, pas de vecteur
+    Qdrant (embedding avec `prospect_id=None`). Sert le mode ad hoc / validation locale."""
     prospects = state.get("prospects") or []
     state.setdefault("erreurs", [])
     state.setdefault("qualifies", 0)
@@ -438,6 +442,7 @@ async def scoring_node(state: EtatAgent) -> EtatAgent:
     criteres = state["criteres"]
     icp_embedding = state.get("icp_embedding")
     config_scoring = state.get("config_scoring")
+    dry_run = bool(state.get("dry_run"))
     settings = get_settings()
 
     # Rendu 1×/campagne (system = candidat au cache) ; un seul client Claude pour le lot.
@@ -445,18 +450,26 @@ async def scoring_node(state: EtatAgent) -> EtatAgent:
     async with anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key) as client:
         for prospect in prospects:
             try:
-                prospect_id = await upsert_prospect(prospect.to_db_dict())
                 score_regles = _score_regles(prospect, criteres)
                 user_rendu = rendre_user(prospect)
                 llm = await _score_llm(
                     client, system_rendu, user_rendu, score_regles_fallback=score_regles
                 )
-                score_embedding = await _score_embedding(prospect, icp_embedding, prospect_id)
-                resultat = await agreger_et_sauvegarder(
-                    prospect_id, score_regles, llm, score_embedding, config_scoring,
-                    modele_llm=settings.claude_scoring_model,
-                )
-                if _statut_pour_score(resultat.score_final) == "qualifie":
+                if dry_run:
+                    # Aucune écriture : embedding sans persistance (id=None), agrégation pure.
+                    score_embedding = await _score_embedding(prospect, icp_embedding, None)
+                    score_final, statut = _agreger(
+                        score_regles, llm["score"], score_embedding, config_scoring
+                    )
+                else:
+                    prospect_id = await upsert_prospect(prospect.to_db_dict())
+                    score_embedding = await _score_embedding(prospect, icp_embedding, prospect_id)
+                    resultat = await agreger_et_sauvegarder(
+                        prospect_id, score_regles, llm, score_embedding, config_scoring,
+                        modele_llm=settings.claude_scoring_model,
+                    )
+                    statut = _statut_pour_score(resultat.score_final)
+                if statut == "qualifie":
                     state["qualifies"] += 1
             except Exception as exc:  # un prospect en échec ne casse pas la campagne (#28)
                 logger.warning(

--- a/agents/sirene_agent.py
+++ b/agents/sirene_agent.py
@@ -159,6 +159,7 @@ async def sirene_node(state: EtatAgent, limit: int = 500) -> EtatAgent:
     """
     criteres: CriteresCiblage = state["criteres"]
     campagne_id = state["campagne_id"]
+    limit = state.get("limit") or limit  # plafond CLI (#29) prioritaire sur le défaut
     api_key = get_settings().insee_api_key
     if not api_key:
         raise RuntimeError("INSEE_API_KEY manquante (voir .env / config.settings).")

--- a/graph/state.py
+++ b/graph/state.py
@@ -24,6 +24,10 @@ class EtatAgent(TypedDict, total=False):
     prospects: list[Prospect]
     config_scoring: dict  # poids des 3 couches (depuis campagnes.config_scoring)
 
+    # Paramètres d'exécution (posés par le CLI #29)
+    limit: int       # plafond de collecte (sirene) ; défaut node = 500
+    dry_run: bool    # True → aucune écriture BDD/Qdrant (scoring en mémoire)
+
     # Suivi d'exécution
     erreurs: list[str]
     collectes: int

--- a/graph/workflow.py
+++ b/graph/workflow.py
@@ -60,6 +60,12 @@ async def init_campagne(etat: EtatAgent) -> EtatAgent:
         `etat` enrichi avec `client_id`, `criteres` (CriteresCiblage),
         `icp_embedding` (**vecteur** `list[float]` de l'ICP, ou None), `config_scoring`.
     """
+    # Mode ad hoc (#29) : si l'état est déjà peuplé (criteres synthétisés depuis les
+    # flags CLI --depts/--naf, sans campagne en base), init_campagne est un no-op —
+    # on ne relit pas la BDD. Idempotent aussi si le node est ré-exécuté.
+    if etat.get("criteres") is not None:
+        return etat
+
     campagne_id_raw = etat.get("campagne_id")
     if not campagne_id_raw:
         raise CampagneIntrouvableError(

--- a/main.py
+++ b/main.py
@@ -1,23 +1,29 @@
 """Point d'entrée CLI — Agent IA de Prospection B2B (multi-secteurs).
 
-Issue #11 (Sprint 1) — STUB. L'implémentation complète du CLI argparse et de
-l'orchestration du pipeline est portée par l'issue #29. Ici on ne pose que la
-structure : `python main.py --help` doit fonctionner même sans pipeline.
+Issue #29 — pilote le pipeline (`graph.workflow.run`, #28) via `argparse`.
+Trois modes :
+- `--campagne-id <uuid>` : charge une campagne en base et lance le pipeline complet
+  (écrit prospects + scores, sauf `--dry-run`).
+- `--depts/--naf [--limit]` : mode **ad hoc** (tests locaux) — ICP synthétisé depuis
+  les flags, pipeline en mémoire, **dry-run forcé** (aucune écriture ; `upsert_prospect`
+  exige un `campagne_id` en base, absent ici).
+- `--list-campagnes` : liste les campagnes existantes et leur statut (lecture seule).
 
-Aucune valeur métier (ICP) codée en dur — l'ICP vient de la base
-(`criteres_ciblage`), voir `docs/ARCHITECTURE.md` et CLAUDE.md règle #3.
+Aucune valeur métier (ICP) codée en dur : en mode campagne l'ICP vient de la base
+(`criteres_ciblage`) ; en ad hoc, les codes NAF / départements sont des **paramètres
+CLI** explicites, pas des defaults globaux (CLAUDE.md règle #3).
 """
 from __future__ import annotations
 
 import argparse
+import asyncio
 import codecs
 import io
 import sys
 
 
 def _is_utf8(encoding: str) -> bool:
-    """True si l'encodage est sémantiquement UTF-8 (gère utf-8, utf_8, utf-8-sig,
-    cp65001… via `codecs.lookup` plutôt qu'une comparaison de chaîne fragile)."""
+    """True si l'encodage est sémantiquement UTF-8 (utf-8, utf_8, utf-8-sig, cp65001…)."""
     try:
         return codecs.lookup(encoding).name == "utf-8"
     except (LookupError, TypeError):
@@ -25,14 +31,8 @@ def _is_utf8(encoding: str) -> bool:
 
 
 def _force_utf8_stdio() -> None:
-    """Force stdout/stderr en UTF-8 — sinon `--help` crash sur console cp1252
-    Windows (UnicodeEncodeError sur les accents français / flèches). Idempotent.
-
-    On reconfigure stdout/stderr (pas stdin : pas d'input interactif au stub).
-    `except` large : `reconfigure` peut lever `OSError`/`io.UnsupportedOperation`
-    si le flux sous-jacent est fermé ou non reconfigurable (redirection vers un
-    fd fermé, wrapper personnalisé) — on préfère ne jamais crasher au démarrage.
-    """
+    """Force stdout/stderr en UTF-8 — sinon `--help`/résumés crashent sur console
+    cp1252 Windows (accents français). Idempotent, jamais bloquant au démarrage."""
     for stream in (sys.stdout, sys.stderr):
         encoding = getattr(stream, "encoding", "") or ""
         if not _is_utf8(encoding):
@@ -44,53 +44,155 @@ def _force_utf8_stdio() -> None:
                     pass
 
 
+def _split_csv(valeur: str | None) -> list[str]:
+    """'75, 92' -> ['75', '92'] ; None/'' -> []."""
+    return [x.strip() for x in valeur.split(",") if x.strip()] if valeur else []
+
+
 def _build_parser() -> argparse.ArgumentParser:
-    """Construit le parser CLI. STUB — les sous-commandes sont des placeholders."""
     parser = argparse.ArgumentParser(
         prog="prospection-b2b",
         description=(
-            "Agent IA de prospection B2B générique — scrape, enrichit, score "
-            "(règles + Claude + embeddings Qdrant) et génère une file d'appel "
-            "triée selon l'ICP du client (configuré en base)."
+            "Agent IA de prospection B2B générique — collecte (Sirene), enrichit, "
+            "score (règles + Claude + embeddings Qdrant) et persiste la file d'appel, "
+            "selon l'ICP du client (configuré en base)."
         ),
     )
-    sub = parser.add_subparsers(dest="command", metavar="<command>", required=True)
-
-    # --- run : lancement d'une campagne (détail dans #29) ---
-    p_run = sub.add_parser("run", help="Lance une campagne de prospection pour un client.")
-    p_run.add_argument("--client-id", required=False, help="UUID du client (icp_profiles).")
-    p_run.add_argument("--depts", help="Départements cibles, ex. 75,92 (ex. --dry-run).")
-    p_run.add_argument("--limit", type=int, default=50, help="Nombre max de prospects.")
-    p_run.add_argument("--dry-run", action="store_true", help="Sans écriture en base ni appel.")
-
-    # --- init-icp : bootstrap ICP d'un client (#12) — --client-id obligatoire ---
-    p_icp = sub.add_parser("init-icp", help="Génère l'embedding ICP d'un client → Qdrant (#12).")
-    p_icp.add_argument("--client-id", required=True, help="UUID du client (icp_profiles).")
-
-    # --- smoke : vérifie que la stack répond ---
-    sub.add_parser("smoke", help="Vérifie que la stack (PG, Qdrant, Ollama) répond.")
-
+    parser.add_argument(
+        "--campagne-id", metavar="UUID",
+        help="UUID d'une campagne existante — lance le pipeline complet.",
+    )
+    parser.add_argument(
+        "--depts", metavar="75,92",
+        help="Départements (mode ad hoc, dry-run forcé).",
+    )
+    parser.add_argument(
+        "--naf", metavar="45.20A,45.20B",
+        help="Codes NAF (mode ad hoc). Sirene itère départements × NAF.",
+    )
+    parser.add_argument(
+        "--limit", type=int, metavar="N",
+        help="Plafond de prospects collectés (défaut pipeline : 500).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Exécute le pipeline sans AUCUNE écriture en base / Qdrant.",
+    )
+    parser.add_argument(
+        "--list-campagnes", action="store_true",
+        help="Liste les campagnes existantes et leur statut (lecture seule).",
+    )
     return parser
 
 
+def _print_resume(titre: str, etat: dict, dry_run: bool) -> None:
+    tag = " [DRY-RUN]" if dry_run else ""
+    print(
+        f"{titre}{tag} — collectés: {etat.get('collectes', 0)}, "
+        f"qualifiés: {etat.get('qualifies', 0)}, "
+        f"erreurs: {len(etat.get('erreurs', []))}"
+    )
+    for err in etat.get("erreurs", [])[:5]:
+        print(f"  ! {err}", file=sys.stderr)
+
+
+async def _lister_campagnes() -> int:
+    from utils import db
+    try:
+        pool = await db.get_pg_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                "SELECT id, nom, statut, prospects_collectes, prospects_qualifies "
+                "FROM campagnes ORDER BY nom;"
+            )
+        if not rows:
+            print("Aucune campagne en base.")
+        for r in rows:
+            print(
+                f"{r['id']}  [{r['statut']}]  {r['nom']}  — "
+                f"collectés: {r['prospects_collectes']}, qualifiés: {r['prospects_qualifies']}"
+            )
+        return 0
+    finally:
+        await db.close()
+
+
+async def _run_campagne(campagne_id: str, limit: int | None, dry_run: bool) -> int:
+    import uuid
+    from graph.workflow import run
+    from utils import db
+
+    try:
+        uuid.UUID(campagne_id)
+    except (ValueError, TypeError):
+        print(f"[erreur] --campagne-id invalide : '{campagne_id}' (UUID attendu).", file=sys.stderr)
+        return 2
+
+    state: dict = {"campagne_id": campagne_id, "dry_run": dry_run}
+    if limit is not None:
+        state["limit"] = limit
+    try:
+        etat = await run(state)
+    finally:
+        await db.close()
+
+    _print_resume(f"Campagne {campagne_id}", etat, dry_run)
+    # Un échec de node prérequis (campagne/ICP introuvable, Sirene KO) est capté par
+    # `run` dans `state["erreurs"]` → code de sortie non nul + message déjà affiché.
+    erreurs = etat.get("erreurs", [])
+    prereq_ko = any(e.startswith(("init_campagne:", "fetch_sirene:")) for e in erreurs)
+    return 1 if prereq_ko else 0
+
+
+async def _run_adhoc(depts: str | None, naf: str | None, limit: int | None) -> int:
+    import uuid
+    from graph.workflow import run
+    from models.criteres import CriteresCiblage
+    from utils import db
+
+    criteres = CriteresCiblage(
+        nom=f"ad-hoc {depts or ''} {naf or ''}".strip(),
+        codes_naf=_split_csv(naf),
+        departements=_split_csv(depts),
+    )
+    state: dict = {
+        "campagne_id": str(uuid.uuid4()),  # jetable — ad hoc = dry-run, jamais persisté
+        "criteres": criteres,              # → init_campagne no-op (état pré-peuplé)
+        "config_scoring": {},              # poids par défaut à l'agrégation
+        "icp_embedding": None,             # pas d'ICP embarqué en ad hoc → couche neutre
+        "dry_run": True,                   # forcé : pas de campagne en base pour persister
+    }
+    if limit is not None:
+        state["limit"] = limit
+    try:
+        etat = await run(state)
+    finally:
+        await db.close()
+
+    _print_resume("Ad hoc", etat, dry_run=True)
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Entry point CLI. STUB — orchestration réelle dans #29."""
     _force_utf8_stdio()
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    # `sub.required=True` → argparse impose une sous-commande. Si `argv` est vide
-    # (ex. `python main.py` sans argument), `parse_args` imprime l'usage et sort
-    # avec code 2 lui-même ; on n'arrive donc jamais ici sans `args.command`.
+    if args.list_campagnes:
+        return asyncio.run(_lister_campagnes())
 
-    # TODO(#29): dispatcher vers graph/workflow.run() (issue #28).
-    # Les imports des modules métier sont faits en lazy ici pour garder
-    # `main.py --help` fonctionnel tant que les stubs ne sont pas implémentés.
-    print(
-        f"[stub] Commande '{args.command}' non implémentée (voir issue #29).",
-        file=sys.stderr,
-    )
-    return 2
+    mode_adhoc = bool(args.depts or args.naf)
+    if args.campagne_id and mode_adhoc:
+        parser.error("--depts/--naf (mode ad hoc) sont exclusifs de --campagne-id.")
+    if not args.campagne_id and not mode_adhoc:
+        parser.error(
+            "Rien à faire : fournir --campagne-id, ou --depts/--naf (ad hoc), "
+            "ou --list-campagnes."
+        )
+
+    if args.campagne_id:
+        return asyncio.run(_run_campagne(args.campagne_id, args.limit, args.dry_run))
+    return asyncio.run(_run_adhoc(args.depts, args.naf, args.limit))
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,109 @@
+"""Tests du CLI (#29) — routing des modes + internals des commandes.
+
+Purs : `graph.workflow.run` et `utils.db` sont monkeypatchés → aucun accès stack.
+Le mode ad hoc DOIT forcer `dry_run` (pas de campagne en base pour persister).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import main
+
+VALID_UUID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+# --- Routing (main() → bonne commande / erreurs d'usage) --------------------
+
+def _stub_cmd(store, key):
+    async def _fn(*args, **kw):
+        store[key] = args
+        return 0
+    return _fn
+
+
+def test_route_list_campagnes(monkeypatch):
+    appels = {}
+    monkeypatch.setattr(main, "_lister_campagnes", _stub_cmd(appels, "list"))
+    assert main.main(["--list-campagnes"]) == 0
+    assert "list" in appels
+
+
+def test_route_campagne(monkeypatch):
+    appels = {}
+    monkeypatch.setattr(main, "_run_campagne", _stub_cmd(appels, "camp"))
+    assert main.main(["--campagne-id", VALID_UUID, "--limit", "10", "--dry-run"]) == 0
+    assert appels["camp"] == (VALID_UUID, 10, True)
+
+
+def test_route_adhoc(monkeypatch):
+    appels = {}
+    monkeypatch.setattr(main, "_run_adhoc", _stub_cmd(appels, "adhoc"))
+    assert main.main(["--depts", "75,92", "--naf", "45.20A"]) == 0
+    assert appels["adhoc"] == ("75,92", "45.20A", None)
+
+
+def test_conflit_campagne_et_adhoc_exit_2():
+    with pytest.raises(SystemExit) as exc:
+        main.main(["--campagne-id", VALID_UUID, "--depts", "75"])
+    assert exc.value.code == 2
+
+
+def test_aucun_mode_exit_2():
+    with pytest.raises(SystemExit) as exc:
+        main.main([])
+    assert exc.value.code == 2
+
+
+# --- Internals des commandes (run / db monkeypatchés) -----------------------
+
+def _patch_run(monkeypatch, retour):
+    """Patch graph.workflow.run (capture le state) + utils.db.close (no-op)."""
+    import graph.workflow as wf
+    from utils import db
+    capture = {}
+
+    async def _fake_run(state):
+        capture["state"] = state
+        return retour
+
+    async def _fake_close():
+        capture["closed"] = True
+
+    monkeypatch.setattr(wf, "run", _fake_run)
+    monkeypatch.setattr(db, "close", _fake_close)
+    return capture
+
+
+def test_run_campagne_construit_le_state(monkeypatch):
+    cap = _patch_run(monkeypatch, {"collectes": 3, "qualifies": 1, "erreurs": []})
+    rc = asyncio.run(main._run_campagne(VALID_UUID, 10, dry_run=True))
+    assert rc == 0
+    assert cap["state"]["campagne_id"] == VALID_UUID
+    assert cap["state"]["dry_run"] is True and cap["state"]["limit"] == 10
+    assert cap["closed"] is True          # pool fermé même en succès
+
+
+def test_run_campagne_uuid_invalide_ne_lance_rien(monkeypatch):
+    cap = _patch_run(monkeypatch, {})
+    rc = asyncio.run(main._run_campagne("pas-un-uuid", None, dry_run=False))
+    assert rc == 2 and "state" not in cap  # run jamais appelé
+
+
+def test_run_campagne_echec_prerequis_code_1(monkeypatch):
+    cap = _patch_run(monkeypatch, {"erreurs": ["init_campagne: campagne introuvable"]})
+    rc = asyncio.run(main._run_campagne(VALID_UUID, None, dry_run=False))
+    assert rc == 1 and "state" in cap      # a bien tourné, mais prérequis KO
+
+
+def test_run_adhoc_force_dry_run_et_synthetise_l_icp(monkeypatch):
+    cap = _patch_run(monkeypatch, {"collectes": 0, "qualifies": 0, "erreurs": []})
+    rc = asyncio.run(main._run_adhoc("75,92", "45.20A,45.20B", 50))
+    assert rc == 0
+    st = cap["state"]
+    assert st["dry_run"] is True                        # ad hoc = dry-run forcé
+    assert st["criteres"].departements == ["75", "92"]
+    assert st["criteres"].codes_naf == ["45.20A", "45.20B"]
+    assert st["limit"] == 50 and st["icp_embedding"] is None
+    assert "campagne_id" in st                          # UUID jetable présent

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -319,6 +319,41 @@ def test_scoring_node_sans_prospects_ne_fait_rien(monkeypatch):
     assert ids == [] and out["qualifies"] == 0
 
 
+def test_scoring_node_dry_run_n_ecrit_rien(monkeypatch):
+    """dry-run (#29) : pas d'upsert, pas d'`agreger_et_sauvegarder` ; score via `_agreger`
+    (réel), embedding sans persistance Qdrant (id=None), qualifiés quand même comptés."""
+    appels = {"upsert": 0, "agreger": 0, "emb_id": "?"}
+
+    async def _no_upsert(data):
+        appels["upsert"] += 1
+        return "id"
+
+    async def _no_agreger(*a, **k):
+        appels["agreger"] += 1
+
+    async def _fake_llm(client, s, u, score_regles_fallback):
+        return {"score": 100, "justification": "", "signaux_positifs": [],
+                "signaux_negatifs": [], "priorite": "haute"}
+
+    async def _fake_emb(prospect, icp, prospect_id=None):
+        appels["emb_id"] = prospect_id
+        return 1.0
+
+    monkeypatch.setattr(sa.anthropic, "AsyncAnthropic", _FakeAsyncClient)
+    monkeypatch.setattr(sa, "upsert_prospect", _no_upsert)
+    monkeypatch.setattr(sa, "agreger_et_sauvegarder", _no_agreger)
+    monkeypatch.setattr(sa, "_score_llm", _fake_llm)
+    monkeypatch.setattr(sa, "_score_embedding", _fake_emb)
+
+    state = {"prospects": [_p("A")], "criteres": _criteres(),
+             "icp_embedding": None, "config_scoring": {}, "dry_run": True}
+    out = asyncio.run(sa.scoring_node(state))
+    assert appels["upsert"] == 0 and appels["agreger"] == 0   # AUCUNE écriture
+    assert appels["emb_id"] is None                            # embedding non persisté
+    # _agreger(0 règles, 100 llm, 1.0 emb, défaut) = 45 + 20 = 65 -> qualifie
+    assert out["qualifies"] == 1
+
+
 # --- Couche 3 : cosinus pur (#26) -------------------------------------------
 def test_cosinus_vecteurs_identiques():
     assert _cosinus([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == pytest.approx(1.0)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -71,13 +71,14 @@ def test_main_help_runs() -> None:
     )
     assert result.returncode == 0, f"main.py --help a échoué :\n{result.stderr}"
     assert "prospection" in result.stdout.lower()
-    assert "run" in result.stdout
-    assert "init-icp" in result.stdout
-    assert "smoke" in result.stdout
+    # CLI à flags plats (#29) : les 3 modes doivent apparaître dans l'aide.
+    assert "--campagne-id" in result.stdout
+    assert "--list-campagnes" in result.stdout
+    assert "--dry-run" in result.stdout
 
 
 def test_main_no_command_errors() -> None:
-    """`python main.py` sans sous-commande → usage error (exit 2, subparsers required)."""
+    """`python main.py` sans aucun mode → usage error (exit 2)."""
     result = subprocess.run(
         [sys.executable, "main.py"],
         capture_output=True,
@@ -86,7 +87,8 @@ def test_main_no_command_errors() -> None:
         errors="replace",
         cwd=_REPO_ROOT,
     )
-    # Subparsers required=True → argparse sort avec code 2 (usage error).
+    # main() appelle parser.error(...) quand ni --campagne-id, ni --depts/--naf,
+    # ni --list-campagnes → argparse sort avec code 2 (usage error).
     assert result.returncode == 2
     assert "usage:" in result.stderr.lower() or "usage:" in result.stdout.lower()
 


### PR DESCRIPTION
## #29 — CLI `main.py` (argparse) pilotant le pipeline

Rebasé sur `main` à jour (`2eee8bf`, avec #27/#28/OSM). Dernier maillon du cœur Sprint 3.

### Contenu — 3 modes (flags plats)
- `--campagne-id <uuid>` : charge la campagne et lance le pipeline complet (`graph.workflow.run`), ferme le pool en `finally`.
- `--depts/--naf [--limit]` : **mode ad hoc** (tests locaux) — ICP synthétisé depuis les flags, pipeline en mémoire, **dry-run forcé** (`upsert_prospect` exige un `campagne_id` en base, absent ici).
- `--list-campagnes` : liste les campagnes existantes + statut (lecture seule).
- Validation d'usage claire : UUID invalide → code 2 ; args manquants / `--campagne-id` + ad hoc → `parser.error`. Remplace le stub #11 (sous-commandes) par les flags plats spécifiés en #29.

### Modifs transverses (additives, rétro-compatibles)
- `agents/scoring_agent.py` — branche **`dry_run`** dans `scoring_node` : score en mémoire via `_agreger`, **aucune** écriture (pas d'`upsert`/`save_score`/vecteur Qdrant).
- `graph/state.py` — champs `limit` + `dry_run`. `agents/sirene_agent.py` — honore `state["limit"]`. `graph/workflow.py` — `init_campagne` no-op si `criteres` déjà peuplés (chemin ad hoc). Ces édits touchent des fichiers voisins mais restent compatibles (défauts inchangés).

### Décision de conception
- **Ad hoc = dry-run only** : un run réel sans campagne ne peut pas persister (`campagne_id` NOT NULL). L'ad hoc synthétise un ICP éphémère et force le dry-run.
- Pas de flag `--osm-tags` (l'ICP ad hoc n'a pas d'`osm_tags` → OSM y est no-op) — ajout naturel ultérieur.

### Tests — 291 → 301 verts (`-m "not integration"`)
9 tests CLI (routing des 3 modes, erreurs d'usage, construction du state, ad hoc force le dry-run) + 1 test `scoring_node` dry-run (aucune écriture). `test_structure` mis à jour (aide en flags plats).

⚠️ **AC E2E** (`--campagne-id` réel, `--dry-run` sans écriture BDD vérifiée par diff) = stack docker requise → non exécutables hors stack. Le no-écriture du dry-run est prouvé au niveau `scoring_node` ; diff BDD complet couvert en #31/#32.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
