### PR TITLE
fix(scoring): normalise le NAF (point INSEE ↔ dot-less ICP) — évite un -30 systématique

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -87,6 +87,18 @@ def _score_mots_cles_positifs(prospect: Prospect, mots_cles: list[str] | None) -
     return min(hits * 5, 10)
 
 
+def _naf_sans_point(naf: str | None) -> str:
+    """Normalise un code NAF pour comparaison : sans point, en majuscules.
+
+    L'INSEE renvoie le code AVEC point (`45.20A`) — c'est la forme stockée dans
+    `prospect.code_naf` — tandis que `criteres_ciblage.codes_naf` le stocke SANS
+    point (`4520A`), cf. `sirene_agent._naf_avec_point` qui insère le point pour
+    interroger l'API. Sans cette normalisation, la comparaison NAF échouait
+    toujours (dotted ≠ dotless) et infligeait la pénalité -30 à TOUT prospect —
+    y compris ceux dont le NAF matche pourtant parfaitement l'ICP."""
+    return (naf or "").replace(".", "").upper()
+
+
 def _score_regles(prospect: Prospect, criteres: CriteresCiblage) -> int:
     """Score règles 0-100, déterministe, entièrement paramétré par l'ICP client.
 
@@ -131,7 +143,9 @@ def _score_regles(prospect: Prospect, criteres: CriteresCiblage) -> int:
         return 0  # exclusion ICP (règle #4) — prime sur tout le reste
     if not prospect.telephone and not prospect.email:
         score -= 20
-    if criteres.codes_naf and prospect.code_naf not in criteres.codes_naf:
+    if criteres.codes_naf and _naf_sans_point(prospect.code_naf) not in {
+        _naf_sans_point(n) for n in criteres.codes_naf
+    }:
         score -= 30
 
     return max(0, min(100, score))

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -195,6 +195,20 @@ def test_regles_penalite_naf_hors_icp():
     assert _score_regles(dehors, crit) == 25   # 35 + 20 - 30
 
 
+def test_regles_naf_normalise_point_insee():
+    """Régression : le NAF INSEE réel arrive AVEC point (`45.20A`) alors que
+    `criteres_ciblage.codes_naf` est stocké SANS point (`4520A`, cf.
+    `sirene._naf_avec_point`). La comparaison doit normaliser les deux, sinon la
+    pénalité -30 frappait à tort TOUT prospect réel (dotted ≠ dotless)."""
+    crit = _criteres(codes_naf=["4520A", "4520B"], effectif_min=2, effectif_max=15)
+    # Prospect réel : code_naf avec point → matche l'ICP dot-less après normalisation.
+    dedans = _p(code_naf="45.20A", effectif_estime=8, telephone=TEL_OK, email=EMAIL_OK)
+    assert _score_regles(dedans, crit) == 55   # 35 + 20, PAS de -30
+    # Contrôle : un NAF réellement hors ICP reste pénalisé.
+    dehors = _p(code_naf="68.20B", effectif_estime=8, telephone=TEL_OK, email=EMAIL_OK)
+    assert _score_regles(dehors, crit) == 25   # 35 + 20 - 30
+
+
 def test_regles_codes_naf_vides_pas_de_penalite():
     """ICP sans codes_naf : aucune pénalité NAF, quel que soit le code du prospect."""
     crit = _criteres(codes_naf=[], effectif_min=2, effectif_max=15)


### PR DESCRIPTION
## Problème
`_score_regles` comparait `prospect.code_naf` (format INSEE **avec** point, ex. `55.10Z`)
à `criteres_ciblage.codes_naf` (stocké **sans** point, ex. `5510Z` — cf. `sirene._naf_avec_point`
qui insère le point pour interroger l'API). La comparaison échouait donc **toujours** sur
données réelles → pénalité **-30 infligée à TOUT prospect**, y compris ceux dont le NAF matche
parfaitement l'ICP.

## Preuve (mesurée)
Un hôtel/garage conforme scorait **45 au lieu de 75**. Sur 100 hôtels réels (audit #32),
`score_regles` avait un **p50 = 0** (moitié des prospects planchés par le -30). Re-agrégation
appariée (mêmes prospects/LLM/embedding) : **qualifiés 14 → 17**, invalides 21 → 15, +5.9 pts de
score final moyen.

## Correctif
Helper `_naf_sans_point` (retire le point + majuscule) appliqué **des deux côtés** de la
comparaison. Test de régression `test_regles_naf_normalise_point_insee` (NAF INSEE dotté matche
un ICP dot-less ; un NAF réellement hors ICP reste pénalisé -30). `test_scoring.py` : 68 → 69.

Découvert pendant l'audit #32 (première exécution du pipeline en **mode campagne** sur données
INSEE réelles — le mode ad hoc masquait le bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)