### PR TITLE
fix(campagne): débloque le mode campagne — osm_tags manquant au schéma + updated_at inexistant

### DIFF
--- a/docker/postgres/init/01_schema.sql
+++ b/docker/postgres/init/01_schema.sql
@@ -45,6 +45,10 @@ CREATE TABLE IF NOT EXISTS criteres_ciblage (
     exiger_email        BOOLEAN NOT NULL DEFAULT FALSE,
     mots_cles_positifs  TEXT[] NOT NULL DEFAULT '{}',
     mots_cles_negatifs  TEXT[] NOT NULL DEFAULT '{}',
+    -- Tags OSM/Overpass (ex. 'tourism=hotel') pour la pré-passe d'enrichissement
+    -- gratuite (#69). Lu par init_campagne + modèle CriteresCiblage — la colonne
+    -- manquait au schéma, ce qui faisait échouer init_campagne en mode campagne.
+    osm_tags            TEXT[] NOT NULL DEFAULT '{}',
     actif               BOOLEAN NOT NULL DEFAULT TRUE,
     CHECK (effectif_max >= effectif_min)
 );

--- a/scripts/init_icp.py
+++ b/scripts/init_icp.py
@@ -234,9 +234,12 @@ async def _run(client_id_str: str) -> int:
                     """
                     UPDATE icp_profiles
                     SET qdrant_point_id = $2,
-                        embedding_version = $3,
-                        updated_at = NOW()
+                        embedding_version = $3
                     WHERE id = $1;
+                    -- NB : `icp_profiles` n'a PAS de colonne `updated_at` (seul
+                    -- `created_at` existe, cf. 01_schema.sql) — ne pas la SET,
+                    -- sinon l'UPDATE échoue et `qdrant_point_id` n'est jamais
+                    -- persisté → couche embedding (#26) muette en mode campagne.
                     """,
                     icp_profile_id,
                     icp_profile_id,


### PR DESCRIPTION
## Problème
Deux régressions rendaient le pipeline **en mode campagne** (`init_campagne` #16 + `init_icp` #12)
inopérant sur toute BDD conforme au schéma. Masquées jusqu'ici : le mode ad hoc (#29) court-circuite
`init_campagne`, et `init_icp` n'avait jamais tourné de bout en bout. **Découvertes pendant l'audit #32.**

### 1. `criteres_ciblage.osm_tags` absent de `01_schema.sql`
`init_campagne` la `SELECT` et `CriteresCiblage` la mappe (pré-passe OSM #69), mais la colonne
n'avait **jamais** été ajoutée au schéma → `UndefinedColumnError`, node prérequis en échec,
pipeline stoppé. **Le VPS aurait planté au premier `--campagne-id`.**
→ ajout `osm_tags TEXT[] NOT NULL DEFAULT '{}'`.

### 2. `init_icp.py` UPDATE `icp_profiles.updated_at`
La table n'a **pas** cette colonne (seul `created_at` existe) → l'UPDATE échouait toujours,
`qdrant_point_id` n'était **jamais** persisté → `init_campagne` lisait NULL → `icp_embedding=None`
→ la **couche embedding (#26) restait muette (0.0)** en mode campagne. Le vecteur, lui, était bien
upserté dans Qdrant.
→ retrait de `updated_at = NOW()` de l'UPDATE.

## Note migration
`01_schema.sql` ne s'exécute qu'au **premier** boot d'un volume Postgres. Les BDD déjà créées
doivent recevoir `ALTER TABLE criteres_ciblage ADD COLUMN osm_tags TEXT[] NOT NULL DEFAULT '{}';`
(appliqué manuellement sur la stack locale pour l'audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)