### PR TITLE
feat(#30): trace l'appel Claude dans LangSmith (@traceable) + activation au démarrage

### DIFF
--- a/agents/scoring_agent.py
+++ b/agents/scoring_agent.py
@@ -36,6 +36,22 @@ from utils.embeddings import get_embedding
 
 logger = logging.getLogger(__name__)
 
+# Observabilité LangSmith (#30) — OPTIONNELLE. `@traceable` trace l'appel Claude
+# (latence, tokens, coût) quand LANGCHAIN_TRACING_V2 + une clé sont présents (config
+# propagée par `utils.tracing.configure_tracing`, appelée au démarrage du pipeline).
+# Import gardé : si `langsmith` n'est pas installé, le décorateur devient un no-op —
+# le scoring fonctionne à l'identique, sans traçage (jamais de dépendance dure).
+try:
+    from langsmith import traceable
+except ImportError:  # pragma: no cover - langsmith optionnel
+    def traceable(*d_args, **d_kwargs):  # type: ignore[misc]
+        """No-op : supporte @traceable ET @traceable(...) quand langsmith est absent."""
+        if d_args and callable(d_args[0]) and not d_kwargs:
+            return d_args[0]
+        def _decore(fn):
+            return fn
+        return _decore
+
 # Environnement Jinja des templates de prompt (rendus dynamiquement depuis l'ICP, #25).
 _PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
 _JINJA_ENV = Environment(loader=FileSystemLoader(str(_PROMPTS_DIR)), autoescape=False)
@@ -205,6 +221,7 @@ def _fallback_llm(score_regles: int, raison: str) -> dict:
     }
 
 
+@traceable(run_type="llm", name="score_llm_claude")
 async def _score_llm(
     client: anthropic.AsyncAnthropic,
     system_rendu: str,

--- a/graph/workflow.py
+++ b/graph/workflow.py
@@ -22,6 +22,7 @@ from agents.sirene_agent import sirene_node
 from graph.state import EtatAgent
 from models.criteres import CriteresCiblage
 from utils import db
+from utils.tracing import configure_tracing
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +213,10 @@ async def run(state: EtatAgent) -> EtatAgent:
     `state` doit contenir `campagne_id`. Retourne l'état final (avec `qualifies`,
     `erreurs`). La fermeture du pool PG / client Qdrant est du ressort de
     l'orchestrateur appelant (`main.py`, #29), pas de `run`."""
+    # Observabilité LangSmith (#30) : active le traçage si LANGCHAIN_TRACING_V2 + une clé
+    # sont présents (idempotent, propagation env-only). L'appel Claude tracé porte
+    # `@traceable` dans scoring_agent. Sans config, no-op silencieux.
+    configure_tracing()
     state.setdefault("erreurs", [])
     state.setdefault("collectes", 0)
     state.setdefault("qualifies", 0)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -63,3 +63,35 @@ def test_endpoint_optionnel_non_pose_si_vide(monkeypatch):
     ))
     assert tracing.configure_tracing() is True
     assert "LANGCHAIN_ENDPOINT" not in os.environ
+
+
+# --- #30 : câblage effectif du traçage (décorateur + orchestrateur) ----------
+
+def test_score_llm_porte_traceable():
+    """L'appel Claude `_score_llm` est décoré `@traceable` (observabilité #30).
+
+    Import gardé : langsmith installé → le décorateur enrobe la fonction (attribut
+    `__wrapped__` posé par functools.wraps) ; absent → no-op, la fonction reste
+    appelable. Dans les deux cas `traceable` existe et `_score_llm` est callable."""
+    import agents.scoring_agent as sa
+    assert callable(sa.traceable)
+    assert callable(sa._score_llm)
+    try:
+        import langsmith  # noqa: F401
+    except ImportError:
+        return  # décorateur no-op : rien de plus à asserter
+    assert hasattr(sa._score_llm, "__wrapped__")
+
+
+def test_run_configure_le_tracage(monkeypatch):
+    """`graph.workflow.run` active le traçage au démarrage (#30) avant les nodes."""
+    import asyncio
+
+    from graph import workflow
+
+    appels: list[int] = []
+    monkeypatch.setattr(workflow, "configure_tracing", lambda: appels.append(1) or False)
+    # État vide : init_campagne (prérequis) lève faute de campagne_id → run stoppe.
+    # `configure_tracing` est appelé AVANT la boucle, donc bien enregistré.
+    asyncio.run(workflow.run({}))
+    assert appels, "run() doit appeler configure_tracing au démarrage"


### PR DESCRIPTION
`Closes #30`

Câble le traçage LangSmith **effectif** (le scaffolding config venait de #95).

## Changements
- **`agents/scoring_agent.py`** : `@traceable(run_type="llm", name="score_llm_claude")` sur
  `_score_llm` (l'appel Claude). **Import gardé** : si `langsmith` absent, `traceable` devient un
  no-op (supporte `@traceable` et `@traceable(...)`) — aucune dépendance dure, le scoring tourne
  à l'identique sans traçage.
- **`graph/workflow.py`** : `run()` appelle `configure_tracing()` au démarrage (idempotent, env-only ;
  propage `LANGCHAIN_*` si `LANGCHAIN_TRACING_V2` + clé présents).

## Vérifié en vrai sur la stack
`configure_tracing()` → True, l'appel Claude passe par `@traceable` et POST vers LangSmith.
⚠️ **Ingestion refusée `403 Forbidden`** avec la clé `.env` actuelle (len 32, atypique) : elle
s'authentifie (`/info` OK) mais n'a pas le droit d'écrire dans le projet `prospection-b2b`.
**La confirmation visuelle des traces attend une clé LangSmith à droits d'ingestion** (`lsv2_pt_...`).

## Tests
`test_score_llm_porte_traceable` (décorateur appliqué) + `test_run_configure_le_tracage`
(run l'active au démarrage). `langsmith` déjà dans `requirements.txt` (l.31 ; à installer dans le venv).
Suite : 291 → **293 passed / 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)