### PR TITLE
fix: robustesse stack locale — timeouts Overpass + pgAdmin crash-loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,12 @@ services:
     restart: unless-stopped
     profiles: ["dev"]
     environment:
-      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@prospection.local}
+      # ⚠️ pgadmin4 récent REFUSE les domaines réservés (.local/.test/.example) au boot
+      # ("special-use or reserved name") → crash-loop. Défaut = TLD réel + on désactive
+      # le contrôle de délivrabilité (login local, aucun mail envoyé).
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@prospection-b2b.io}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-changeme_pgadmin}
+      PGADMIN_CONFIG_CHECK_EMAIL_DELIVERABILITY: "False"
     ports:
       - "${PGADMIN_PORT:-5050}:80"
     volumes:

--- a/utils/osm.py
+++ b/utils/osm.py
@@ -162,7 +162,10 @@ def _construire_requete_overpass(osm_tags: list[str], bbox: tuple[float, float, 
         clauses.append(f"  node{sel}{zone};")
         clauses.append(f"  way{sel}{zone};")
     corps = "\n".join(clauses)
-    return f"[out:json][timeout:60];\n(\n{corps}\n);\nout center tags;"
+    # timeout serveur court (25 s) : les bbox sont petites (code postal) → réponse
+    # rapide quand Overpass est sain ; en cas de surcharge (429/504) on préfère
+    # échouer vite et laisser la cascade payante prendre le relais (#69).
+    return f"[out:json][timeout:25];\n(\n{corps}\n);\nout center tags;"
 
 
 def _parser_pois(data: dict) -> list[POI]:
@@ -220,7 +223,11 @@ async def interroger_overpass(
                 url, data={"data": requete},
                 headers={"User-Agent": USER_AGENT,
                          "Content-Type": "application/x-www-form-urlencoded"},
-                timeout=90.0,
+                # Timeout client borné (30 s) aligné sur le timeout serveur (25 s) :
+                # quand Overpass est dégradé (429/504), on échoue vite et on passe au
+                # miroir suivant plutôt que d'attendre 90 s × N miroirs (la pré-passe
+                # OSM #69 bloquait le pipeline plusieurs minutes en cas de surcharge).
+                timeout=30.0,
             )
             resp.raise_for_status()
             return _parser_pois(resp.json())


### PR DESCRIPTION
Deux correctifs d'ops repérés pendant l'audit #32 (indépendants, base `main`).

## 1. `utils/osm.py` — timeouts Overpass bornés
La pré-passe OSM (#69) interroge chaque miroir avec un timeout client **90 s** + serveur
`[out:json][timeout:60]`. Overpass surchargé (429/504, observé pendant l'audit) → chaque miroir
met jusqu'à 90 s à échouer → **le pipeline bloquait plusieurs minutes** avant la cascade (un run
100 prospects est passé de ~5 à ~15 min). Serveur 60→**25 s**, client 90→**30 s** : bbox petites
(code postal) → Overpass sain répond en quelques secondes ; sinon échec rapide → cascade payante.
`tests/test_osm.py` : 14 passed.

## 2. `docker-compose.yml` — pgAdmin crash-loop
`dpage/pgadmin4:latest` récent refuse au boot les TLD réservés (`.local`) → le container `pgadmin`
(profil dev) **crash-loopait**. Défaut `admin@prospection.local` → `admin@prospection-b2b.io` +
`PGADMIN_CONFIG_CHECK_EMAIL_DELIVERABILITY=False`. **Vérifié en local** : container "Up" (plus de
restart). UI seulement, aucun impact pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)