### PR TITLE
test(#31/#32): récupère les tests #31 sur main + garde de régression mode campagne

### DIFF
--- a/tests/test_campagne_mode_regression.py
+++ b/tests/test_campagne_mode_regression.py
@@ -1,0 +1,120 @@
+"""Test d'intégration (#31/#32) — régression du MODE CAMPAGNE.
+
+Garde les 3 bugs trouvés pendant l'audit #32 qu'AUCUN test n'attrapait : tous les
+tests existants tournent en mode **ad hoc** (init_campagne court-circuité), or les
+3 bugs vivent dans le chemin **campagne** (`--campagne-id`) :
+
+  #1 NAF non normalisé dans `_score_regles` (INSEE dotté `55.10Z` vs ICP dot-less
+     `5510Z`) → pénalité -30 à tort. Couvert unitairement (#102) ; re-vérifié ici
+     via l'invariant de normalisation.
+  #2 colonne `criteres_ciblage.osm_tags` absente du schéma → `init_campagne` plantait
+     (`UndefinedColumnError`).
+  #3 `init_icp` UPDATE `icp_profiles.updated_at` (colonne inexistante) → `qdrant_point_id`
+     jamais persisté → couche embedding (#26) muette en mode campagne.
+
+Exerce le VRAI chemin campagne (script `init_icp` réel + node `init_campagne`) contre
+Postgres + Qdrant + Ollama. Données isolées (UUID aléatoires), supprimées en teardown.
+
+    pytest tests/test_campagne_mode_regression.py -m integration -v
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from agents.scoring_agent import _score_regles
+from graph.workflow import init_campagne
+from models.criteres import CriteresCiblage
+from models.prospect import Prospect
+from utils import db
+
+pytestmark = pytest.mark.integration
+
+
+@pytest_asyncio.fixture
+async def campagne_seedee():
+    """Seed client + critère (avec osm_tags + NAF dot-less) + icp_profile + campagne,
+    UUID aléatoires. Teardown : DELETE client (CASCADE) + point Qdrant + close pool."""
+    client_id, critere_id, icp_id, camp_id = (uuid.uuid4() for _ in range(4))
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as c:
+        await c.execute(
+            "INSERT INTO clients (id, nom_entreprise, secteur, produit_vendu, "
+            "zone_intervention, statut) VALUES ($1,$2,'conseil','x','France','essai');",
+            client_id, "Regress SARL",
+        )
+        await c.execute(
+            "INSERT INTO criteres_ciblage (id, client_id, nom, description_icp, codes_naf, "
+            "departements, effectif_min, effectif_max, anciennete_min_ans, "
+            "mots_cles_positifs, osm_tags) "
+            "VALUES ($1,$2,'crit regress','Hotels independants Paris',ARRAY['5510Z'],"
+            "ARRAY['75'],2,50,2,ARRAY['hotel'],ARRAY['tourism=hotel']);",
+            critere_id, client_id,
+        )
+        await c.execute(
+            "INSERT INTO icp_profiles (id, client_id, critere_id, nom, description, actif) "
+            "VALUES ($1,$2,$3,'icp regress','Hotels independants Paris',TRUE);",
+            icp_id, client_id, critere_id,
+        )
+        await c.execute(
+            "INSERT INTO campagnes (id, client_id, critere_id, icp_profile_id, nom, statut) "
+            "VALUES ($1,$2,$3,$4,'camp regress','brouillon');",
+            camp_id, client_id, critere_id, icp_id,
+        )
+    try:
+        yield {"client_id": client_id, "icp_id": icp_id, "camp_id": camp_id}
+    finally:
+        async with pool.acquire() as c:
+            await c.execute("DELETE FROM clients WHERE id=$1;", client_id)  # CASCADE
+        try:
+            await db.get_qdrant().delete(
+                collection_name=db.COLLECTION_ICP, points_selector=[str(icp_id)]
+            )
+        except Exception:
+            pass
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_mode_campagne_bout_en_bout(campagne_seedee):
+    ids = campagne_seedee
+
+    # --- #3 : le SCRIPT init_icp réel doit persister qdrant_point_id -----------
+    # (si l'UPDATE touchait `updated_at` inexistant, exit 2 + qdrant_point_id NULL).
+    env = {**os.environ, "PYTHONIOENCODING": "utf-8", "PYTHONPATH": "."}
+    r = subprocess.run(
+        [sys.executable, "scripts/init_icp.py", "--client-id", str(ids["client_id"])],
+        capture_output=True, text=True, timeout=180, env=env,
+    )
+    assert r.returncode == 0, f"init_icp a échoué (régression #3) : {r.stdout}\n{r.stderr}"
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as c:
+        qpid = await c.fetchval(
+            "SELECT qdrant_point_id FROM icp_profiles WHERE id=$1;", ids["icp_id"]
+        )
+    assert qpid is not None, "init_icp n'a pas persisté qdrant_point_id (régression #3)"
+
+    # --- #2 + #3 : init_campagne lit osm_tags ET résout l'embedding ICP --------
+    etat = await init_campagne({"campagne_id": str(ids["camp_id"])})
+    crit: CriteresCiblage = etat["criteres"]
+    assert list(crit.osm_tags) == ["tourism=hotel"], "osm_tags non chargé (régression #2)"
+    emb = etat["icp_embedding"]
+    assert emb is not None and len(emb) == 768, \
+        "embedding ICP non résolu en mode campagne (régression #3)"
+
+    # --- #1 : NAF INSEE dotté doit scorer comme le dot-less (invariant) --------
+    def _p(naf: str) -> Prospect:
+        return Prospect(
+            campagne_id=ids["camp_id"], nom_entreprise="HOTEL TEST", code_naf=naf,
+            departement="75", telephone="+33140000000", email="c@hotel-test.fr",
+            effectif_estime=8,
+        )
+    dotte = _score_regles(_p("55.10Z"), crit)   # forme INSEE réelle
+    dot_less = _score_regles(_p("5510Z"), crit)  # forme ICP stockée
+    assert dotte == dot_less, f"NAF dotté pénalisé à tort ({dotte} != {dot_less}, régression #1)"
+    assert dotte >= 60, f"score règles inattendu ({dotte}) — NAF matché devrait qualifier"

--- a/tests/test_e2e_run.py
+++ b/tests/test_e2e_run.py
@@ -1,0 +1,182 @@
+"""Tests d'intégration (#31) — pipeline complet assemblé `graph.workflow.run` (#28).
+
+Deux critères d'acceptance du Sprint 3 :
+
+1. **Débit** : `run()` traite ~100 prospects réels en < 15 min (collecte Sirene →
+   OSM → enrichissement → nettoyage → scoring), en mode ad hoc / dry-run (aucune
+   écriture — c'est exactement le chemin de `main.py --depts/--naf`, #29).
+2. **Résilience panne Claude** : si l'API Claude est indisponible, `scoring_node`
+   bascule seul sur le repli (score règles + embedding) — la campagne ne s'arrête
+   pas, aucun prospect ne fait échouer le lot (#28).
+
+⚠️ Le test de **débit** est coûteux (vraies APIs Sirene/Tavily) → double opt-in :
+marqué `integration` (exclu du run par défaut) ET gardé par `RUN_E2E=1`. Lancer :
+
+    RUN_E2E=1 pytest tests/test_e2e_run.py -m integration -s
+
+Tout est paramétrable par variable d'env (aucune valeur métier codée en dur,
+règle #3) : `E2E_DEPTS` / `E2E_NAF` / `E2E_LIMIT` / `E2E_MAX_SECONDS`.
+
+Le test de **résilience** est déterministe et léger (prospects synthétiques,
+Claude simulé en panne) : il ne dépend que d'Ollama (embedding local) et tourne
+avec `-m integration` sans `RUN_E2E`.
+"""
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import anthropic
+import httpx
+import pytest
+import pytest_asyncio
+
+from utils import db
+
+pytestmark = pytest.mark.integration
+
+_RUN_E2E = os.getenv("RUN_E2E") == "1"
+
+
+@pytest_asyncio.fixture
+async def _clean_db_pool():
+    """Ferme le pool PG singleton après le test (voir test_init_campagne)."""
+    yield
+    await db.close()
+
+
+# --- AC1 : débit du pipeline complet (100 prospects < 15 min) ---------------
+
+@pytest.mark.skipif(
+    not _RUN_E2E,
+    reason="E2E live coûteux — activer avec RUN_E2E=1 (tape Sirene/Tavily).",
+)
+@pytest.mark.asyncio
+async def test_run_pipeline_100_prospects_sous_15min(_clean_db_pool) -> None:
+    """`run()` en mode ad hoc (dry-run) sur ~100 prospects réels, < 15 min, 0 erreur.
+
+    Reproduit fidèlement le chemin `main.py --depts/--naf --limit` (#29) : ICP
+    synthétisé depuis les flags, `init_campagne` no-op (état pré-peuplé), scoring
+    en mémoire (aucune écriture). La borne de temps est l'AC #31 (« 100 prospects
+    < 15 min »). Le pipeline doit rester à 0 erreur même si Claude est indisponible
+    (le repli du scoring absorbe la panne)."""
+    from graph.workflow import run
+    from models.criteres import CriteresCiblage
+
+    limit = int(os.getenv("E2E_LIMIT", "100"))
+    max_seconds = float(os.getenv("E2E_MAX_SECONDS", "900"))  # 15 min (AC #31)
+
+    criteres = CriteresCiblage(
+        nom="E2E débit",
+        departements=os.getenv("E2E_DEPTS", "75,92").split(","),
+        codes_naf=os.getenv("E2E_NAF", "45.20A").split(","),
+    )
+    state = {
+        "campagne_id": str(uuid.uuid4()),  # jetable — dry-run, jamais persisté
+        "criteres": criteres,              # → init_campagne no-op
+        "config_scoring": {},              # poids par défaut à l'agrégation
+        "icp_embedding": None,             # pas d'ICP embarqué → couche embedding neutre
+        "dry_run": True,                   # aucune écriture BDD/Qdrant
+        "limit": limit,
+    }
+
+    t0 = time.monotonic()
+    etat = await run(state)
+    duree = time.monotonic() - t0
+
+    prospects = etat.get("prospects") or []
+    print(
+        f"\nE2E run — collectés: {etat.get('collectes', 0)}, "
+        f"prospects: {len(prospects)}, qualifiés: {etat.get('qualifies', 0)}, "
+        f"erreurs: {len(etat.get('erreurs', []))}, durée: {duree:.0f}s"
+    )
+    for err in etat.get("erreurs", [])[:5]:
+        print(f"  ! {err}")
+
+    # AC1 : le pipeline collecte, produit des prospects, et tient la borne de temps.
+    assert prospects, "Sirene n'a renvoyé aucun prospect (collecte vide)."
+    assert etat.get("collectes", 0) > 0
+    assert duree < max_seconds, f"pipeline {duree:.0f}s ≥ {max_seconds:.0f}s pour {len(prospects)} prospects"
+    # AC #28 : aucun node prérequis en échec, aucun prospect ne casse le lot.
+    assert etat.get("erreurs", []) == [], f"erreurs non vides : {etat['erreurs'][:5]}"
+    assert isinstance(etat.get("qualifies"), int)
+
+
+# --- AC2 : résilience à une panne Claude (repli du scoring) ------------------
+
+class _FakeMessagesDown:
+    """Simule l'API Messages de Claude en panne : chaque appel lève une APIError."""
+
+    async def create(self, **_kwargs):
+        raise anthropic.APIConnectionError(
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        )
+
+
+class _FakeClaudeDown:
+    """Remplace `anthropic.AsyncAnthropic` : contexte async dont `.messages.create`
+    lève toujours (panne API). Exerce le repli réel de `_score_llm` (#25/#28)."""
+
+    def __init__(self, *_args, **_kwargs):
+        self.messages = _FakeMessagesDown()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_scoring_node_survit_a_une_panne_claude(_clean_db_pool, monkeypatch) -> None:
+    """AC #28/#31 : Claude down → `scoring_node` bascule sur le repli, 0 erreur.
+
+    Prospects synthétiques (pas de collecte réseau), ICP embarqué factice non nul
+    pour exercer la couche embedding réelle (Ollama, règle #5). Claude est simulé
+    en panne : `scoring_node` doit terminer sans exception, sans pousser d'erreur,
+    et compter les qualifiés issus du repli (règles + embedding)."""
+    from agents.scoring_agent import scoring_node
+    from models.criteres import CriteresCiblage
+    from models.prospect import Prospect
+
+    monkeypatch.setattr(
+        "agents.scoring_agent.anthropic.AsyncAnthropic", _FakeClaudeDown
+    )
+
+    criteres = CriteresCiblage(
+        nom="résilience",
+        codes_naf=["45.20A"],
+        departements=["75"],
+        effectif_min=0,
+        effectif_max=10_000,
+    )
+    campagne_id = uuid.uuid4()
+    prospects = [
+        Prospect(
+            campagne_id=campagne_id,
+            nom_entreprise=f"Garage Test {i}",
+            code_naf="45.20A",
+            departement="75",
+            ville="Paris",
+            telephone="+33140000000",
+            email=f"contact{i}@garage-test.fr",
+            effectif_estime=8,
+        )
+        for i in range(3)
+    ]
+    state = {
+        "criteres": criteres,
+        "prospects": prospects,
+        "icp_embedding": [0.01] * 768,  # non nul → embedding réel via Ollama
+        "config_scoring": {},
+        "dry_run": True,                # aucune écriture — pas de campagne en base
+    }
+
+    etat = await scoring_node(state)
+
+    # La panne Claude n'a pas cassé le lot : aucune exception remontée, 0 erreur.
+    assert etat.get("erreurs", []) == [], f"erreurs inattendues : {etat.get('erreurs')}"
+    assert isinstance(etat.get("qualifies"), int)
+    # Les 3 prospects ont été traités (repli appliqué), aucun n'a fait échouer le node.
+    assert etat is state

--- a/tests/test_persistance_counter.py
+++ b/tests/test_persistance_counter.py
@@ -1,0 +1,173 @@
+"""Test d'intégration (#31) — garde SQL du compteur `prospects_qualifies`.
+
+Vérifie, contre un **vrai PostgreSQL** (stack docker locale), l'invariant du
+compteur de qualifiés posé par `utils.db.save_score` (#27) :
+
+    `campagnes.prospects_qualifies` n'est incrémenté QUE sur une transition de
+    statut vers `qualifie` (ancien statut ≠ `qualifie`).
+
+L'historique `scores` autorisant plusieurs lignes par prospect, sans cette garde
+un simple re-scoring double-compterait les qualifiés. Ce test exerce la vraie
+requête `FOR UPDATE` + l'`UPDATE … + 1` conditionnel dans la transaction réelle —
+ce qu'un test unitaire mocké ne peut pas garantir.
+
+⚠️ `@integration` (exclu du run par défaut, voir conftest.py) : nécessite le
+Postgres de la stack (`docker compose --profile dev up -d`). Lancer :
+
+    pytest tests/test_persistance_counter.py -m integration -v
+
+Données isolées : un client + critère + campagne jetables (UUID aléatoires),
+supprimés en fin de test. Aucune valeur métier sectorielle codée en dur
+(règle #3) — placeholders neutres.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from utils import db
+
+pytestmark = pytest.mark.integration
+
+
+async def _qualifies(campagne_id: uuid.UUID) -> int:
+    """Lit le compteur courant `prospects_qualifies` de la campagne."""
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT prospects_qualifies FROM campagnes WHERE id = $1;", campagne_id
+        )
+
+
+async def _nb_scores(prospect_id: str) -> int:
+    """Compte les lignes d'historique `scores` d'un prospect."""
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT COUNT(*) FROM scores WHERE prospect_id = $1;", uuid.UUID(prospect_id)
+        )
+
+
+async def _statut(prospect_id: str) -> str:
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as conn:
+        return await conn.fetchval(
+            "SELECT statut FROM prospects WHERE id = $1;", uuid.UUID(prospect_id)
+        )
+
+
+@pytest_asyncio.fixture
+async def campagne_jetable():
+    """Crée client + critère + campagne isolés (UUID aléatoires) et les supprime
+    en fin de test. Ferme ensuite le pool PG singleton (même raison que
+    `_clean_db_pool` de test_init_campagne : éviter le partage d'une connexion en
+    cours de reset entre tests d'intégration)."""
+    client_id = uuid.uuid4()
+    critere_id = uuid.uuid4()
+    campagne_id = uuid.uuid4()
+
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO clients (id, nom_entreprise, secteur, produit_vendu, "
+            "zone_intervention, statut) "
+            "VALUES ($1, $2, 'conseil', 'x', 'France', 'essai');",
+            client_id, "Compteur SARL",
+        )
+        await conn.execute(
+            "INSERT INTO criteres_ciblage (id, client_id, nom, codes_naf, departements) "
+            "VALUES ($1, $2, 'crit test compteur', ARRAY['6201Z'], ARRAY['75']);",
+            critere_id, client_id,
+        )
+        await conn.execute(
+            "INSERT INTO campagnes (id, client_id, critere_id, nom, statut) "
+            "VALUES ($1, $2, $3, 'camp test compteur', 'brouillon');",
+            campagne_id, client_id, critere_id,
+        )
+    try:
+        yield campagne_id
+    finally:
+        # Suppression explicite dans l'ordre inverse des dépendances (CASCADE gère
+        # prospects + scores via campagnes ; on retire ensuite critère puis client).
+        async with pool.acquire() as conn:
+            await conn.execute("DELETE FROM campagnes WHERE id = $1;", campagne_id)
+            await conn.execute("DELETE FROM criteres_ciblage WHERE id = $1;", critere_id)
+            await conn.execute("DELETE FROM clients WHERE id = $1;", client_id)
+        await db.close()
+
+
+def _score_data(statut: str, score_final: int) -> dict:
+    """Payload minimal pour `save_score` (les colonnes absentes gardent leur défaut)."""
+    return {
+        "score_regles": score_final,
+        "score_llm": score_final,
+        "score_embedding": 0.0,
+        "score_final": score_final,
+        "statut": statut,
+        "modele_llm": "test-guard",
+    }
+
+
+@pytest.mark.asyncio
+async def test_transition_vers_qualifie_incremente_une_fois(campagne_jetable) -> None:
+    """AC #31 : une transition `nouveau` → `qualifie` incrémente le compteur de 1 ;
+    un re-scoring qui reste `qualifie` ne le ré-incrémente PAS (garde de transition).
+    L'historique `scores`, lui, accumule bien une ligne par scoring."""
+    campagne_id = campagne_jetable
+    assert await _qualifies(campagne_id) == 0
+
+    prospect_id = await db.upsert_prospect({
+        "campagne_id": campagne_id,
+        "nom_entreprise": "Cible Alpha",
+        "siret": "12345678901234",
+    })
+    # Statut initial par défaut du schéma.
+    assert await _statut(prospect_id) == "nouveau"
+
+    # 1er scoring : transition nouveau -> qualifie => compteur +1.
+    await db.save_score(prospect_id, _score_data("qualifie", 82))
+    assert await _statut(prospect_id) == "qualifie"
+    assert await _qualifies(campagne_id) == 1
+    assert await _nb_scores(prospect_id) == 1
+
+    # 2e scoring : reste qualifie => compteur INCHANGÉ (pas de double-comptage),
+    # mais l'historique gagne une 2e ligne.
+    await db.save_score(prospect_id, _score_data("qualifie", 90))
+    assert await _qualifies(campagne_id) == 1
+    assert await _nb_scores(prospect_id) == 2
+
+
+@pytest.mark.asyncio
+async def test_statut_non_qualifie_n_incremente_pas(campagne_jetable) -> None:
+    """Un prospect scoré `nouveau` puis `invalide` ne touche jamais le compteur."""
+    campagne_id = campagne_jetable
+
+    prospect_id = await db.upsert_prospect({
+        "campagne_id": campagne_id,
+        "nom_entreprise": "Cible Beta",
+        "siret": "23456789012345",
+    })
+    await db.save_score(prospect_id, _score_data("nouveau", 45))
+    assert await _qualifies(campagne_id) == 0
+    await db.save_score(prospect_id, _score_data("invalide", 12))
+    assert await _statut(prospect_id) == "invalide"
+    assert await _qualifies(campagne_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_deux_prospects_qualifies_comptent_deux(campagne_jetable) -> None:
+    """Deux prospects distincts qui deviennent qualifiés comptent 2 (le compteur est
+    par campagne, pas par prospect)."""
+    campagne_id = campagne_jetable
+
+    p1 = await db.upsert_prospect({
+        "campagne_id": campagne_id, "nom_entreprise": "Cible Un", "siret": "34567890123456",
+    })
+    p2 = await db.upsert_prospect({
+        "campagne_id": campagne_id, "nom_entreprise": "Cible Deux", "siret": "45678901234567",
+    })
+    await db.save_score(p1, _score_data("qualifie", 70))
+    await db.save_score(p2, _score_data("qualifie", 65))
+    assert await _qualifies(campagne_id) == 2


### PR DESCRIPTION
## ⚠️ Récupération — les tests #31 ne sont PAS sur main
#104 avait pour base la branche `sprint-3/issue-29-cli-main` (empilée sur #101). #101 a fusionné
**sans supprimer sa branche** → GitHub n'a pas retargeté #104 → **#104 a fusionné DANS la branche
#29 (`bcbaa2a`), pas sur `main`**. Le badge « MERGED » est trompeur : `test_persistance_counter.py`
et `test_e2e_run.py` ne sont pas sur `main` (`git merge-base --is-ancestor bcbaa2a origin/main` → faux).
Cette PR (**base `main`**, pas de pile) les y ramène — contenu identique à #104.

## + garde de régression MODE CAMPAGNE (la vraie leçon de l'audit #32)
Les 3 bugs de l'audit vivaient tous dans le chemin **campagne** (`--campagne-id`), qu'**aucun test
n'exerçait** (tous en mode ad hoc → `init_campagne` court-circuité). `tests/test_campagne_mode_regression.py`
(bout-en-bout Postgres+Qdrant+Ollama) les garde tous les 3 :
- **#1** NAF normalisé (invariant : NAF INSEE dotté `55.10Z` score comme l'ICP dot-less `5510Z`) ;
- **#2** `init_campagne` lit `criteres_ciblage.osm_tags` (colonne jadis absente du schéma) ;
- **#3** le **vrai script `init_icp`** persiste `qdrant_point_id` (jadis cassé par `updated_at`), et
  `init_campagne` résout un embedding **non nul**.

Ne passe QUE si les fixes #102 + #103 sont sur `main` (**mesuré vert** : 4 passed sur la stack).
Données isolées (UUID aléatoires), teardown (DELETE CASCADE + point Qdrant).

Réconcilié : **302 passed / 9 skipped** (les 6 tests d'intégration ajoutés sont exclus du run par défaut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)