### PR TITLE
feat(#41): job de purge RGPD automatique — rétention légale + audit + tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PG_VOLUME    = prospection_b2b_postgres_data
 
 .DEFAULT_GOAL := help
 
-.PHONY: help dev prod stop psql logs backup reset-db pull-ollama smoke status
+.PHONY: help dev prod stop psql logs backup reset-db pull-ollama smoke status purge-rgpd purge-rgpd-dry
 
 ## help — Afficher cette aide
 help:
@@ -95,3 +95,9 @@ reset-db:
 	else \
 		echo "Abandon."; \
 	fi
+# --- RGPD (#41) : purge de retention, cron quotidien en prod ----------------
+purge-rgpd:
+	python scripts/purge_rgpd.py
+
+purge-rgpd-dry:
+	python scripts/purge_rgpd.py --dry-run

--- a/scripts/purge_rgpd.py
+++ b/scripts/purge_rgpd.py
@@ -1,0 +1,151 @@
+"""purge_rgpd — applique la politique de rétention RGPD (issue #41).
+
+Job récurrent (cron quotidien, #34) — **jamais** de purge manuelle (CLAUDE.md règle #9).
+Applique les 4 durées de conservation de `docs/LEGAL.md` (§ Durée de conservation) :
+
+    - prospects **invalides**                 → supprimés après **6 mois**
+    - prospects **qualifiés non convertis**    → supprimés après **3 ans**
+    - historique **appels**                    → supprimé après **1 an**
+    - **logs système** (`purge_rgpd_log`)      → supprimés après **3 mois**
+
+Chaque suppression est journalisée dans `purge_rgpd_log` (`table_cible`, `nb_lignes`,
+`motif`) pour l'audit (critère d'acceptance #41).
+
+⚠️ **`oppositions_rgpd` n'est JAMAIS purgée.** Un SIRET opposé ne doit plus jamais être
+recontacté, indépendamment de la purge (#41). La table est clé-primée sur `siret`, **sans
+FK vers `prospects`** : supprimer un prospect opposé n'efface donc pas son opposition — la
+liste de suppression survit à la purge et reste opposable aux campagnes futures.
+
+Ancre temporelle :
+    - prospects : `created_at` (date de collecte) — lecture *data-minimization* (on ne
+      conserve pas une donnée collectée au-delà de la durée), cohérente avec le critère
+      « prospect invalide de plus de 6 mois ». Supprimer un prospect cascade ses `scores`
+      / `appels` / `bloctel_verifications` (FK `ON DELETE CASCADE`).
+    - appels : `COALESCE(date_appel, created_at)` (l'événement, sinon la création).
+
+« Non converti » = statut resté `qualifie` (un prospect converti passe à `rdv`, exclu).
+
+Les durées viennent de LEGAL.md (constantes légales, pas des valeurs métier ICP de la
+règle #3). Surchargeables par variable d'env **pour les tests uniquement**.
+
+Usage :
+    python scripts/purge_rgpd.py             # applique la purge + journalise
+    python scripts/purge_rgpd.py --dry-run   # compte seulement, AUCUNE suppression
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import codecs
+import os
+import sys
+from pathlib import Path
+
+# Permet `python scripts/purge_rgpd.py` depuis la racine du repo sans install.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils import db  # noqa: E402
+
+# Table de suppression RGPD à NE JAMAIS purger (garde-fou explicite, cf. docstring).
+_TABLE_INTOUCHABLE = "oppositions_rgpd"
+
+
+def _intervalle(env: str, defaut: str) -> str:
+    """Intervalle Postgres pour une règle. Défaut = LEGAL.md ; surcharge env pour tests."""
+    return os.getenv(env, defaut)
+
+
+def _regles() -> tuple[tuple[str, str, str], ...]:
+    """(table_cible, motif, clause WHERE) — l'ordre est sans importance (règles disjointes).
+
+    Les valeurs (table/WHERE) sont des constantes internes, jamais des entrées externes :
+    pas de risque d'injection SQL."""
+    return (
+        (
+            "prospects", "prospects invalides > 6 mois",
+            f"statut = 'invalide' AND created_at < now() - INTERVAL '{_intervalle('RGPD_INVALIDES', '6 months')}'",
+        ),
+        (
+            "prospects", "prospects qualifies non convertis > 3 ans",
+            f"statut = 'qualifie' AND created_at < now() - INTERVAL '{_intervalle('RGPD_QUALIFIES', '3 years')}'",
+        ),
+        (
+            "appels", "historique appels > 1 an",
+            f"COALESCE(date_appel, created_at) < now() - INTERVAL '{_intervalle('RGPD_APPELS', '1 year')}'",
+        ),
+        (
+            "purge_rgpd_log", "logs systeme > 3 mois",
+            f"purge_le < now() - INTERVAL '{_intervalle('RGPD_LOGS', '3 months')}'",
+        ),
+    )
+
+
+async def purger(dry_run: bool = False) -> list[tuple[str, str, int]]:
+    """Applique (ou simule si `dry_run`) les règles de rétention. Retourne la liste
+    `(table_cible, motif, nb_lignes)`. Chaque suppression réelle est journalisée dans
+    `purge_rgpd_log` **dans la même transaction** que la suppression (atomicité)."""
+    resultats: list[tuple[str, str, int]] = []
+    pool = await db.get_pg_pool()
+    for table, motif, where in _regles():
+        assert table != _TABLE_INTOUCHABLE, f"garde-fou : {_TABLE_INTOUCHABLE} ne se purge jamais"
+        async with pool.acquire() as conn:
+            if dry_run:
+                nb = await conn.fetchval(f"SELECT count(*) FROM {table} WHERE {where};")
+            else:
+                async with conn.transaction():
+                    nb = await conn.fetchval(
+                        f"WITH del AS (DELETE FROM {table} WHERE {where} RETURNING 1) "
+                        f"SELECT count(*) FROM del;"
+                    )
+                    # Journal d'audit — sauf si rien supprimé (pas de bruit).
+                    if nb:
+                        await conn.execute(
+                            "INSERT INTO purge_rgpd_log (table_cible, nb_lignes, motif) "
+                            "VALUES ($1, $2, $3);",
+                            table, nb, motif,
+                        )
+        resultats.append((table, motif, nb))
+    return resultats
+
+
+def _force_utf8_stdio() -> None:
+    """stdout/stderr en UTF-8 (accents FR sur console Windows). Idempotent."""
+    for stream in (sys.stdout, sys.stderr):
+        enc = getattr(stream, "encoding", "") or ""
+        try:
+            if codecs.lookup(enc).name != "utf-8":
+                stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except (LookupError, AttributeError, ValueError, TypeError, OSError):
+            pass
+
+
+async def _run(dry_run: bool) -> int:
+    try:
+        resultats = await purger(dry_run=dry_run)
+    finally:
+        await db.close()
+    tag = " [DRY-RUN]" if dry_run else ""
+    total = sum(n for _, _, n in resultats)
+    print(f"Purge RGPD{tag} — {total} ligne(s) {'à supprimer' if dry_run else 'supprimée(s)'} :")
+    for table, motif, nb in resultats:
+        print(f"  {nb:>6}  {table:16s} {motif}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    _force_utf8_stdio()
+    parser = argparse.ArgumentParser(
+        prog="purge-rgpd",
+        description="Applique la politique de rétention RGPD (docs/LEGAL.md). Job récurrent, "
+                    "jamais manuel (CLAUDE.md règle #9).",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Compte seulement les lignes concernées, sans rien supprimer.",
+    )
+    args = parser.parse_args(argv)
+    return asyncio.run(_run(args.dry_run))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_purge_rgpd.py
+++ b/tests/test_purge_rgpd.py
@@ -1,0 +1,164 @@
+"""Test d'intégration (#41) — purge RGPD contre un vrai PostgreSQL.
+
+Vérifie les 4 durées de rétention (docs/LEGAL.md), le journal d'audit
+`purge_rgpd_log`, l'exclusion de `oppositions_rgpd` (jamais purgée), et le `--dry-run`
+(lecture seule). Seed daté finement (INSERT avec `created_at` explicite) + teardown.
+
+    pytest tests/test_purge_rgpd.py -m integration -v
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from scripts.purge_rgpd import purger
+from utils import db
+
+pytestmark = pytest.mark.integration
+
+SIRET_OPPOSE = "11111111111111"
+
+
+@pytest_asyncio.fixture
+async def donnees_datees():
+    """Seed client + campagne + prospects/appels/opposition/log à des âges contrôlés.
+    Retourne les ids utiles. Teardown : DELETE client (CASCADE) + opposition + logs du test."""
+    client_id, critere_id, camp_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as c:
+        depart = await c.fetchval("SELECT now();")  # borne pour nettoyer les logs du run
+        await c.execute(
+            "INSERT INTO clients (id, nom_entreprise, secteur, produit_vendu, "
+            "zone_intervention, statut) VALUES ($1,'Purge SARL','conseil','x','France','essai');",
+            client_id,
+        )
+        await c.execute(
+            "INSERT INTO criteres_ciblage (id, client_id, nom, codes_naf, departements) "
+            "VALUES ($1,$2,'crit purge',ARRAY['6201Z'],ARRAY['75']);",
+            critere_id, client_id,
+        )
+        await c.execute(
+            "INSERT INTO campagnes (id, client_id, critere_id, nom, statut) "
+            "VALUES ($1,$2,$3,'camp purge','brouillon');",
+            camp_id, client_id, critere_id,
+        )
+
+        async def _prospect(nom: str, statut: str, age: str, siret: str | None = None) -> uuid.UUID:
+            return await c.fetchval(
+                "INSERT INTO prospects (campagne_id, nom_entreprise, siret, statut, created_at) "
+                f"VALUES ($1,$2,$3,$4, now() - INTERVAL '{age}') RETURNING id;",
+                camp_id, nom, siret, statut,
+            )
+
+        ids = {
+            "inv_vieux": await _prospect("Invalide vieux", "invalide", "7 months", SIRET_OPPOSE),
+            "inv_recent": await _prospect("Invalide recent", "invalide", "5 months"),
+            "qual_vieux": await _prospect("Qualifie vieux", "qualifie", "4 years"),
+            "qual_recent": await _prospect("Qualifie recent", "qualifie", "2 years"),
+            "rdv_vieux": await _prospect("Converti vieux", "rdv", "4 years"),
+        }
+        # Appels rattachés au survivant (qual_recent) : un vieux (>1 an) purgé, un récent gardé.
+        await c.execute(
+            "INSERT INTO appels (prospect_id, date_appel) VALUES ($1, now() - INTERVAL '2 years');",
+            ids["qual_recent"],
+        )
+        await c.execute(
+            "INSERT INTO appels (prospect_id, date_appel) VALUES ($1, now() - INTERVAL '1 month');",
+            ids["qual_recent"],
+        )
+        # Opposition (siret identique à inv_vieux) — doit survivre à la purge du prospect.
+        await c.execute(
+            "INSERT INTO oppositions_rgpd (siret, motif) VALUES ($1, 'test') "
+            "ON CONFLICT (siret) DO NOTHING;",
+            SIRET_OPPOSE,
+        )
+        # Vieux log système (> 3 mois) → purgé.
+        await c.execute(
+            "INSERT INTO purge_rgpd_log (table_cible, nb_lignes, motif, purge_le) "
+            "VALUES ('prospects', 1, 'vieux log test', now() - INTERVAL '4 months');",
+        )
+    try:
+        yield {"ids": ids, "camp_id": camp_id, "depart": depart}
+    finally:
+        async with pool.acquire() as c:
+            await c.execute("DELETE FROM clients WHERE id=$1;", client_id)  # CASCADE
+            await c.execute("DELETE FROM oppositions_rgpd WHERE siret=$1;", SIRET_OPPOSE)
+            await c.execute("DELETE FROM purge_rgpd_log WHERE purge_le >= $1;", depart)
+        await db.close()
+
+
+async def _existe(prospect_id: uuid.UUID) -> bool:
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as c:
+        return await c.fetchval("SELECT EXISTS(SELECT 1 FROM prospects WHERE id=$1);", prospect_id)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_ne_supprime_rien(donnees_datees) -> None:
+    """--dry-run compte les cibles mais ne supprime rien (lecture seule)."""
+    ids = donnees_datees["ids"]
+    res = dict(((t, m), n) for t, m, n in await purger(dry_run=True))
+    # Au moins les 2 prospects vieux + 1 appel vieux + 1 vieux log sont comptés.
+    assert res[("prospects", "prospects invalides > 6 mois")] >= 1
+    assert res[("prospects", "prospects qualifies non convertis > 3 ans")] >= 1
+    assert res[("appels", "historique appels > 1 an")] >= 1
+    # Rien n'a bougé.
+    assert await _existe(ids["inv_vieux"]) and await _existe(ids["qual_vieux"])
+
+
+@pytest.mark.asyncio
+async def test_purge_applique_les_4_regles(donnees_datees) -> None:
+    ids = donnees_datees["ids"]
+    depart = donnees_datees["depart"]
+
+    await purger(dry_run=False)
+
+    # Invalides > 6 mois supprimés ; < 6 mois gardés.
+    assert not await _existe(ids["inv_vieux"])
+    assert await _existe(ids["inv_recent"])
+    # Qualifiés non convertis > 3 ans supprimés ; < 3 ans gardés ; convertis (rdv) gardés.
+    assert not await _existe(ids["qual_vieux"])
+    assert await _existe(ids["qual_recent"])
+    assert await _existe(ids["rdv_vieux"]), "un prospect converti (rdv) ne doit PAS être purgé"
+
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as c:
+        # Appels : le vieux (>1 an) est parti, le récent reste.
+        appels_restants = await c.fetchval(
+            "SELECT count(*) FROM appels WHERE prospect_id=$1;", ids["qual_recent"]
+        )
+        assert appels_restants == 1
+        # Vieux log système purgé.
+        vieux_log = await c.fetchval(
+            "SELECT count(*) FROM purge_rgpd_log WHERE motif='vieux log test';"
+        )
+        assert vieux_log == 0
+        # oppositions_rgpd INTOUCHÉE (le SIRET opposé reste opposable même si son prospect a été purgé).
+        assert await c.fetchval("SELECT EXISTS(SELECT 1 FROM oppositions_rgpd WHERE siret=$1);", SIRET_OPPOSE)
+        # Journal d'audit écrit pour les suppressions de ce run.
+        logs = await c.fetch(
+            "SELECT table_cible, motif, nb_lignes FROM purge_rgpd_log WHERE purge_le >= $1;", depart
+        )
+        motifs = {r["motif"]: r["nb_lignes"] for r in logs}
+        assert motifs.get("prospects invalides > 6 mois", 0) >= 1
+        assert motifs.get("historique appels > 1 an", 0) >= 1
+        assert all(r["nb_lignes"] > 0 for r in logs), "aucune ligne de log à 0 (pas de bruit)"
+
+
+@pytest.mark.asyncio
+async def test_run_idempotent(donnees_datees) -> None:
+    """Un 2e run immédiat ne trouve plus rien à purger (0 nouvelle ligne de log)."""
+    depart = donnees_datees["depart"]
+    await purger(dry_run=False)
+    res2 = await purger(dry_run=False)
+    assert all(n == 0 for _, _, n in res2), "le 2e run ne doit plus rien supprimer"
+    pool = await db.get_pg_pool()
+    async with pool.acquire() as c:
+        # Aucune ligne de log ajoutée au 2e run (on ne journalise pas les purges vides)…
+        # on vérifie juste qu'aucune n'a nb_lignes = 0.
+        zero = await c.fetchval(
+            "SELECT count(*) FROM purge_rgpd_log WHERE purge_le >= $1 AND nb_lignes = 0;", depart
+        )
+        assert zero == 0


### PR DESCRIPTION
`Closes #41`

Le job de purge RGPD manquait : `docs/LEGAL.md` documente les durées de conservation mais rien
ne les appliquait. **Obligation légale dès la mise en prod** — #33 le déploie avec la stack.

## Politique appliquée (source : `docs/LEGAL.md` § Durée de conservation)
| Donnée | Rétention | Ancre |
|--------|-----------|-------|
| prospects `invalide` | 6 mois | `created_at` |
| prospects `qualifie` **non convertis** | 3 ans | `created_at` (converti = statut `rdv`, exclu) |
| historique `appels` | 1 an | `COALESCE(date_appel, created_at)` |
| logs système (`purge_rgpd_log`) | 3 mois | `purge_le` |

## `scripts/purge_rgpd.py`
- Job récurrent, **jamais manuel** (CLAUDE.md règle #9). `--dry-run` compte sans supprimer.
- Journalise chaque suppression dans `purge_rgpd_log` (`table_cible`, `nb_lignes`, `motif`) **dans la
  même transaction** que la suppression.
- ⚠️ **`oppositions_rgpd` n'est JAMAIS purgée** : la table est clé-primée sur `siret`, sans FK vers
  `prospects` → supprimer un prospect opposé n'efface pas son opposition (reste opposable aux campagnes
  futures). Testé.
- Ancre `created_at` = lecture *data-minimization*, cohérente avec le critère « prospect invalide de
  plus de 6 mois ». Durées surchargeables par env (`RGPD_INVALIDES`…) **pour les tests uniquement**.

## Cron (à installer sur le VPS, #33/#34)
```cron
# Purge RGPD — quotidien 3h
0 3 * * *  cd /opt/prospection-b2b && make purge-rgpd >> /var/log/purge_rgpd.log 2>&1
```

## Tests — `tests/test_purge_rgpd.py` (3 × `@integration`, vrai Postgres)
Les 4 règles, le journal d'audit, `oppositions_rgpd` intouchée, `--dry-run` read-only, idempotence.
**Mesuré : 3/3 vert** sur la stack. Réconcilié : 304 passed / 12 skipped.

## Critères d'acceptance
- [x] Script appliquant les 4 règles · [x] oppositions vérifiées/préservées · [x] journal `purge_rgpd_log`
- [x] Aucun prospect invalide > 6 mois après un run (testé) · [x] journal consultable
- [ ] Cron installé sur le VPS (dépend de #33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)