### PR TITLE
[fusion libre] chore(icp): ICP agences de com (7311Z) — validation inter-secteurs

### DIFF
--- a/config/icp_agences_com.json
+++ b/config/icp_agences_com.json
@@ -1,0 +1,17 @@
+{
+  "nom_entreprise": "Client Test — Agences de communication",
+  "secteur": "Communication et publicite",
+  "produit_vendu": "Solution SaaS de gestion de projets et de facturation pour agences",
+  "zone_intervention": "Ile-de-France",
+  "nom": "Agences de communication independantes — cible de test",
+  "description_icp": "Agences de communication et de publicite independantes (non affiliees a un grand reseau ou holding), petites et moyennes structures de 2 a 50 salaries, en activite depuis au moins 2 ans, a Paris et en proche couronne.",
+  "codes_naf": ["7311Z"],
+  "departements": ["75", "92"],
+  "effectif_min": 2,
+  "effectif_max": 50,
+  "anciennete_min_ans": 2,
+  "exiger_site_web": false,
+  "exiger_email": false,
+  "mots_cles_positifs": ["communication", "publicite", "agence", "marketing", "branding", "digital", "creation", "strategie", "design", "medias"],
+  "mots_cles_negatifs": ["groupe", "reseau", "holding", "regie"]
+}


### PR DESCRIPTION
## Quoi

Ajoute `config/icp_agences_com.json` : un 2e ICP de test (agences de communication, NAF **7311Z**), miroir de `config/icp_test.json` (hôtels 5510Z) déjà sur main.

## Pourquoi

Support de la **comparaison inter-secteurs** qui valide la généralisation du pipeline (thèse « produit multi-secteurs ») : hôtels = commerce local présent dans OSM, agences = services B2B web-first. Mêmes paramètres (dép. 75/92, effectif 2–50, ancienneté ≥ 2 ans, `exiger_* = false`) ; seuls le NAF, le secteur et les mots-clés changent → l'écart mesuré isole l'effet secteur, pas la config.

## Résultat de la validation (2 × 150 prospects réels, VPS prod)

- ✅ **Le pipeline généralise** : passer d'hôtels à agences = ce fichier JSON, **zéro code**.
- ✅ **Couche Claude robuste inter-secteurs** : score médian 45 = 45, max 85 = 85 ; justifications appliquant la même logique (conformité NAF, exclusions, signaux manquants) sur les 2 secteurs.
- ⚠️ **Couverture contact directionnelle uniquement** : le run agences (2e, séquentiel) a épuisé le quota Tavily gratuit (60 × HTTP 432) → enrichissement dégradé par l'ordre d'exécution. À rejouer agences-en-premier après reset du quota pour une compa contact propre.

## Portée / risque

- **Config uniquement**, aucun code. Base = `main`, PR autonome (pas d'empilement).
- Permet au clone VPS de récupérer le fichier au prochain `git pull` (aujourd'hui scp'é en untracked → évite le piège « name clash » qu'on avait eu avec `icp_test.json`).
- Ne pas fusionner sans le feu vert de John (règle d'équipe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)