### PR TITLE
[fusion libre] feat(deploy): Metabase lié 127.0.0.1 + runbook tunnel (#37)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,3 +33,14 @@ services:
     ports: !override
       - "127.0.0.1:${OLLAMA_PORT:-11434}:11434"
     restart: always
+
+  # Metabase (dashboard KPIs, profil monitoring, #37) — lié à 127.0.0.1 comme les
+  # autres. ⚠️ Docker publie ses ports via iptables et CONTOURNE ufw : sans ce
+  # bind, le port 3000 serait joignable hors du VPS MALGRÉ le pare-feu. Accès en
+  # prod par tunnel SSH uniquement (cf. DEPLOY.md §12). Démarrer avec le profil :
+  #   docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  #     --profile monitoring up -d metabase
+  metabase:
+    ports: !override
+      - "127.0.0.1:${METABASE_PORT:-3000}:3000"
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,12 @@ services:
       - "${METABASE_PORT:-3000}:3000"
     volumes:
       - metabase_data:/metabase.db
-    mem_limit: 1g
+    # Heap JVM explicite : sans ça, la JVM prend ~25% du mem_limit (250 Mo à 1g)
+    # → OutOfMemoryError au boot (crash-loop). 1g de heap boote confortablement ;
+    # mem_limit 2g laisse la marge non-heap (metaspace/threads). Cf. #37.
+    environment:
+      JAVA_OPTS: "-Xmx1g"
+    mem_limit: 2g
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -222,6 +222,42 @@ gunzip -c /opt/backups/AAAAMMJJ-HHMM.sql.gz | \
 
 ---
 
+## 12. Dashboard Metabase (#37) — accès par tunnel SSH 🛠️
+
+Metabase (profil `monitoring`) est **lié à `127.0.0.1` en prod** (`docker-compose.prod.yml`).
+⚠️ Docker publie ses ports via iptables et **contourne `ufw`** : le bind `127.0.0.1` est ce qui
+garde le port 3000 **inaccessible hors du VPS** (à re-vérifier au scan externe, comme 5432/6333).
+
+```bash
+# Sur le VPS — démarrer Metabase (les autres services ne sont pas touchés)
+cd /opt/prospection-b2b
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  --profile monitoring up -d metabase
+docker compose -f docker-compose.yml -f docker-compose.prod.yml ps metabase   # healthy ?
+```
+
+Metabase n'écoutant que sur `127.0.0.1`, on l'atteint **depuis le poste local par un tunnel SSH** :
+
+```bash
+# Sur le poste local — ouvre localhost:3000 -> 127.0.0.1:3000 du VPS
+ssh -i <clé> -L 3000:localhost:3000 <user>@<vps-ip>
+# puis http://localhost:3000 dans le navigateur
+```
+
+**Première connexion (assistant, dans le navigateur)** — à faire par un humain :
+
+1. Créer le compte **admin** Metabase (email + mot de passe — *jamais* via un script).
+2. **Ajouter la base de données** à explorer :
+   - Type : **PostgreSQL**
+   - Host : `postgres` (nom du service — Metabase et Postgres sont sur le même réseau Docker `prospection_net`)
+   - Port : `5432` · Database : `prospection_b2b` · User : `scraper` · Password : celui de `.env` (`POSTGRES_PASSWORD`).
+3. Construire les dashboards KPIs (mêmes métriques que le rapport `#38` : collectés/qualifiés, taux tél/email, score moyen, coût/qualifié — cf. PRD §6).
+
+> Les données Metabase (dashboards, comptes) persistent dans le volume `prospection_b2b_metabase_data`
+> (H2 embarqué). Pour arrêter : `docker compose ... --profile monitoring stop metabase`.
+
+---
+
 ### Récap des dépendances
 
 `#33 (ce runbook)` débloque `#35 (1re campagne)`. `#41 (purge RGPD)` se déploie **avec** la stack


### PR DESCRIPTION
## Quoi

Sécurise et documente le dashboard **Metabase** (#37). Le service existait déjà (`docker-compose.yml`, profil `monitoring`) mais publiait `3000` sur `0.0.0.0`.

## Pourquoi c'est important

⚠️ **Docker publie ses ports via iptables et contourne `ufw`.** Sans bind explicite, le port 3000 serait joignable **hors du VPS malgré le pare-feu** (comme l'auraient été 5432/6333 sans `docker-compose.prod.yml`). 

## Changements

- `docker-compose.prod.yml` : override `metabase.ports !override → 127.0.0.1:${METABASE_PORT:-3000}:3000` (même pattern que postgres/qdrant/ollama).
- `docs/DEPLOY.md` §12 : lancement (`--profile monitoring up -d metabase`), **accès par tunnel SSH** (`ssh -L 3000:localhost:3000`), assistant 1re connexion (compte admin créé par un humain, source de données Postgres `host=postgres`).

## Déploiement

Déployé opérationnellement sur le VPS (via override local en attendant le merge, clone gardé propre). Metabase tourne, lié à `127.0.0.1`. La **construction des dashboards** se fait dans l'UI par un humain → `Refs`, pas `Closes`.

Refs #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)