### PR TITLE
[fusion 2/2 · après #119] chore(deploy): front servi par l'API + accès public ngrok OAuth (Slice 3, #116)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,11 @@
 # permanence dans `git status` sans diff réel. On force LF pour matcher
 # ce que le codegen écrit réellement.
 src/routeTree.gen.ts text eol=lf
+
+# Artefacts de déploiement lus/exécutés sous Linux (VPS) — forcer LF.
+# Le piège CRLF (git archive / autocrlf Windows) casse units systemd & scripts ; cf. CLAUDE.md.
+deploy/serve.py            text eol=lf
+deploy/ngrok/*.py          text eol=lf
+deploy/ngrok/*.yml         text eol=lf
+deploy/ngrok/*.txt         text eol=lf
+deploy/systemd/*.service   text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ agents.md
 .env.*
 !.env.example
 
+# ngrok : emails autorisés réels + policy générée = jamais committés
+# (seuls les *.example sont versionnés — cf. docs/DEPLOY_FRONT_NGROK.md)
+deploy/ngrok/allow_emails.txt
+deploy/ngrok/oauth-policy.yml
 
 # Logs
 logs

--- a/deploy/ngrok/allow_emails.example.txt
+++ b/deploy/ngrok/allow_emails.example.txt
@@ -1,0 +1,5 @@
+# Une adresse email autorisée par ligne. Lignes vides et lignes # ignorées.
+# Copier ce fichier en  allow_emails.txt  (gitignoré) et y mettre les vraies adresses.
+# Le match est insensible à la casse. Cap ngrok gratuit : 5 utilisateurs / mois.
+prenom.nom@gmail.com
+coequipier@gmail.com

--- a/deploy/ngrok/gen_policy.py
+++ b/deploy/ngrok/gen_policy.py
@@ -1,0 +1,58 @@
+"""Génère la traffic-policy ngrok (OAuth + allowlist d'emails) depuis un fichier
+d'adresses (une par ligne).
+
+    python3 deploy/ngrok/gen_policy.py
+
+Entrée  : NGROK_ALLOW_EMAILS   (défaut: /etc/ngrok/allow_emails.txt)
+Sortie  : NGROK_POLICY_OUT     (défaut: /etc/ngrok/oauth-policy.yml)
+Provider: NGROK_OAUTH_PROVIDER (défaut: google ; ex: microsoft, github)
+
+Le match d'email est INSENSIBLE À LA CASSE (lowerAscii() des deux côtés), pour
+qu'une majuscule dans l'allowlist ne bloque pas un login. Le script n'imprime QUE
+le nombre d'adresses, jamais les adresses elles-mêmes (vie privée).
+
+NB ngrok : un endpoint = UN seul provider (pas de choix Google/Microsoft sur la
+même URL). Pour changer de provider, réexporter NGROK_OAUTH_PROVIDER puis relancer.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+SRC = os.environ.get("NGROK_ALLOW_EMAILS", "/etc/ngrok/allow_emails.txt")
+DST = os.environ.get("NGROK_POLICY_OUT", "/etc/ngrok/oauth-policy.yml")
+PROVIDER = os.environ.get("NGROK_OAUTH_PROVIDER", "google")
+
+
+def main() -> int:
+    try:
+        with open(SRC, encoding="utf-8") as fh:
+            emails = [ln.strip() for ln in fh
+                      if ln.strip() and not ln.lstrip().startswith("#")]
+    except FileNotFoundError:
+        print("ERREUR: fichier introuvable:", SRC, file=sys.stderr)
+        return 1
+    if not emails:
+        print("ERREUR: aucune adresse dans", SRC, file=sys.stderr)
+        return 1
+
+    allow = ", ".join("'%s'" % e.lower() for e in emails)
+    policy = (
+        "on_http_request:\n"
+        "  - actions:\n"
+        "      - type: oauth\n"
+        "        config:\n"
+        "          provider: " + PROVIDER + "\n"
+        "  - expressions:\n"
+        '      - "!(actions.ngrok.oauth.identity.email.lowerAscii() in [' + allow + '])"\n'
+        "    actions:\n"
+        "      - type: deny\n"
+    )
+    with open(DST, "w", encoding="utf-8") as fh:
+        fh.write(policy)
+    print("OK: %d email(s) autorise(s) -> %s (provider=%s)" % (len(emails), DST, PROVIDER))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/ngrok/oauth-policy.example.yml
+++ b/deploy/ngrok/oauth-policy.example.yml
@@ -1,0 +1,12 @@
+# EXEMPLE de policy générée par gen_policy.py.
+# La vraie (oauth-policy.yml) est gitignorée — ne jamais committer d'emails réels.
+# Google OAuth + allowlist insensible à la casse ; tout email hors liste => 403.
+on_http_request:
+  - actions:
+      - type: oauth
+        config:
+          provider: google
+  - expressions:
+      - "!(actions.ngrok.oauth.identity.email.lowerAscii() in ['prenom.nom@gmail.com', 'coequipier@gmail.com'])"
+    actions:
+      - type: deny

--- a/deploy/serve.py
+++ b/deploy/serve.py
@@ -1,0 +1,40 @@
+"""Entrypoint ASGI de production : sert le front buildé (dist/) ET l'API sur une
+seule origine (same-origin), pour l'exposer derrière un unique gate/tunnel.
+
+Compose l'app FastAPI de `api.main` (endpoints /api/*) et y monte le build Vite
+(dist/) avec un fallback SPA. Lancer avec :
+
+    uvicorn deploy.serve:app --host 127.0.0.1 --port 8000
+
+Prérequis :
+  - `api/` présent (fusionner la PR #119 d'abord — voir docs/DEPLOY_FRONT_NGROK.md) ;
+  - le front buildé et déposé dans `dist/` à la racine du repo.
+"""
+from __future__ import annotations
+
+import os
+
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from api.main import app  # compose l'app existante ; dépend de la PR #119
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DIST = os.path.join(_ROOT, "dist")
+
+# Sert les assets hashés du build (JS/CSS) si présents.
+if os.path.isdir(os.path.join(_DIST, "assets")):
+    app.mount("/assets", StaticFiles(directory=os.path.join(_DIST, "assets")), name="assets")
+
+
+@app.get("/{full_path:path}", include_in_schema=False)
+async def _serve_spa(full_path: str):
+    """Sert un fichier du build s'il existe, sinon index.html (routing SPA).
+
+    Déclaré APRÈS les routes /api de `api.main` : FastAPI matche les routes
+    spécifiques d'abord, donc ce catch-all ne capte que ce que l'API n'a pas servi.
+    """
+    candidate = os.path.join(_DIST, full_path)
+    if full_path and os.path.isfile(candidate):
+        return FileResponse(candidate)
+    return FileResponse(os.path.join(_DIST, "index.html"))

--- a/deploy/systemd/ngrok-prospection.service
+++ b/deploy/systemd/ngrok-prospection.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=ngrok tunnel — Prospection B2B (OAuth-gated, upstream 127.0.0.1:8000)
+After=network-online.target prospection-api.service
+Wants=network-online.target prospection-api.service
+Requires=prospection-api.service
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+# ngrok lit l'authtoken dans ~/.config/ngrok/ngrok.yml (ubuntu) -> HOME requis.
+Environment=HOME=/home/ubuntu
+# REMPLACER le domaine par le vôtre (ngrok dashboard -> Domains -> dev domain).
+# La policy OAuth+allowlist est générée par deploy/ngrok/gen_policy.py.
+ExecStart=/usr/local/bin/ngrok http 8000 --url https://VOTRE-DOMAINE.ngrok-free.dev --traffic-policy-file /etc/ngrok/oauth-policy.yml --log stdout --log-format logfmt
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/prospection-api.service
+++ b/deploy/systemd/prospection-api.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Prospection B2B — API + front (uvicorn, 127.0.0.1:8000)
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/opt/prospection-b2b
+Environment=PYTHONPATH=.
+# deploy.serve compose api.main + le front dist/ (same-origin). Le pool asyncpg est
+# créé dans le lifespan (sur la loop uvicorn), .env lu depuis WorkingDirectory.
+ExecStart=/opt/prospection-b2b/.venv/bin/uvicorn deploy.serve:app --host 127.0.0.1 --port 8000
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/DEPLOY_FRONT_NGROK.md
+++ b/docs/DEPLOY_FRONT_NGROK.md
@@ -1,0 +1,114 @@
+# Déploiement — front servi par l'API + accès public OAuth (ngrok)
+
+Codifie la « Slice 3 » : le front est servi par l'API sur une seule origine, et l'app
+est exposée sur **un lien public unique protégé par login Google** (ngrok), sans ouvrir
+de port entrant ni toucher au DNS d'un domaine.
+
+> Ces artefacts vivaient jusqu'ici en scp non-tracké sur le VPS. Ce dossier `deploy/` les
+> rend reproductibles. Fichiers versionnés = **templates** ; les vraies valeurs (domaine,
+> emails, authtoken) restent hors git.
+
+## ⚠️ Ordre de fusion (important)
+
+Cette PR **se fusionne APRÈS #119** : `deploy/serve.py` fait `from api.main import app`,
+et `api/` n'arrive sur `main` qu'avec **#119** (qui remplace **#117** — fermer #117, ne pas
+le fusionner). Le front (dist/) se construit depuis **#118**.
+
+Séquence recommandée : **#119** (ferme #117) → **#118** → **cette PR** → puis, sur le VPS,
+`rm -rf api/` **avant** `git pull` (sinon l'`api/` scp'é non-tracké bloque le merge).
+
+## Prérequis
+
+- PR **#119** et **#118** fusionnées sur `main` (api/ + front présents).
+- Node local pour builder le front (pas de node sur le VPS → build local + scp).
+- `fastapi` / `uvicorn` dans le venv du VPS (déjà dans `requirements.txt`).
+- Compte ngrok + **agent authtoken** (dashboard → *Your Authtoken*, PAS l'API key), et un
+  **dev domain** gratuit (dashboard → *Domains*).
+
+## 1. Builder le front (en local)
+
+Base d'API **vide** ⇒ le front appelle `/api/...` en relatif (même origine que l'API) :
+
+```bash
+VITE_API_URL= npm run build          # (ou: pnpm build) ; produit dist/
+grep -rl "localhost:8000" dist && echo "KO: base non vide" || echo "OK: appels /api relatifs"
+```
+
+## 2. Déposer dist/ sur le VPS
+
+`tar` préserve les octets (contrairement à `git archive` sous Windows qui réécrit en CRLF) :
+
+```bash
+tar -C dist -cf - . | ssh -i <clé> ubuntu@"$IP" \
+  'rm -rf /opt/prospection-b2b/dist && mkdir -p /opt/prospection-b2b/dist && tar -C /opt/prospection-b2b/dist -xf -'
+```
+
+## 3. Service API + front (systemd)
+
+```bash
+sudo cp deploy/systemd/prospection-api.service /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now prospection-api
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8000/            # 200 (front)
+curl -s http://127.0.0.1:8000/api/health                                    # {"status":"ok"}
+```
+
+Le unit lance `uvicorn deploy.serve:app` (front dist/ + /api), lié `127.0.0.1:8000`,
+`Restart=always`, démarrage au boot.
+
+## 4. Agent ngrok
+
+```bash
+curl -sSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null
+echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list
+sudo apt-get update && sudo apt-get install -y ngrok
+ngrok config add-authtoken <VOTRE_AGENT_AUTHTOKEN>     # écrit ~/.config/ngrok/ngrok.yml
+```
+
+## 5. Gate OAuth + allowlist
+
+```bash
+sudo mkdir -p /etc/ngrok && sudo chown "$USER" /etc/ngrok
+printf '%s\n' 'toi@gmail.com' > /etc/ngrok/allow_emails.txt     # une adresse par ligne
+python3 deploy/ngrok/gen_policy.py                              # -> /etc/ngrok/oauth-policy.yml
+```
+
+`gen_policy.py` génère un match **insensible à la casse** (`lowerAscii()`). Provider par
+défaut `google` ; pour Outlook/Hotmail : `NGROK_OAUTH_PROVIDER=microsoft python3 deploy/ngrok/gen_policy.py`.
+**Un endpoint = un seul provider** (pas de choix Google/Microsoft sur la même URL).
+
+## 6. Service ngrok
+
+Éditer `ExecStart` de `deploy/systemd/ngrok-prospection.service` : remplacer
+`VOTRE-DOMAINE.ngrok-free.dev` par votre dev domain. Puis :
+
+```bash
+sudo cp deploy/systemd/ngrok-prospection.service /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now ngrok-prospection
+# Vérif depuis l'extérieur : doit rediriger vers le login (gate actif), pas servir l'app.
+curl -sI https://VOTRE-DOMAINE.ngrok-free.dev | grep -iE '^HTTP/|^location:'   # 302 -> idp.ngrok.com
+```
+
+## Ajouter / retirer un testeur
+
+```bash
+echo 'coequipier@gmail.com' >> /etc/ngrok/allow_emails.txt      # ">>" (append, pas ">")
+python3 deploy/ngrok/gen_policy.py
+sudo systemctl restart ngrok-prospection
+```
+
+## Limites & pièges
+
+- **ngrok gratuit** : 1 domaine, **5 utilisateurs/mois** (OAuth), 20 000 req & 1 Go/mois.
+  Au-delà → payer ou passer à Cloudflare Access (migration DNS complète requise, 50 users).
+- **Aucun port entrant** ouvert : l'agent ngrok compose vers l'extérieur (ufw reste sur 22).
+- **CRLF** : après tout transfert de `.py`, revérifier `git hash-object` / `file` (Windows).
+- **`rm -rf api/` avant `git pull`** au premier pull post-#119 (untracked scp qui bloque).
+- Ne jamais committer `deploy/ngrok/allow_emails.txt` ni `oauth-policy.yml` (gitignorés).
+
+## Migration depuis l'état intérimaire
+
+Le VPS tourne aujourd'hui avec `uvicorn api.main:app` **plus** un mount SPA collé en fin de
+`api/main.py` (scp, non-tracké, sauvegarde `api/main.py.bak`). En adoptant cette PR :
+après `rm -rf api/ && git pull` (api/main.py redevient propre), basculer le service sur
+`deploy.serve:app` (déjà le cas dans le unit ci-dessus) — le front-serving vient alors de
+`deploy/serve.py`, plus de l'append. Aucun autre changement.


### PR DESCRIPTION
Codifie la **Slice 3** (front servi par l'API + accès public OAuth ngrok) — jusqu'ici en scp non-tracké sur le VPS — pour la rendre reproductible.

## ⚠️ Ordre de fusion
- **Se fusionne APRÈS #119** : `deploy/serve.py` fait `from api.main import app` (le dossier `api/` arrive sur `main` avec #119).
- **#119 remplace #117** → fusionner #119, **fermer #117** (ne pas merger les deux : conflit `api/`).
- Le front (`dist/`) se build depuis **#118**.
- Sur le VPS, au 1er pull post-#119 : `rm -rf api/` **avant** `git pull` (l'`api/` scp'é non-tracké bloquerait le merge).

## Contenu
- `deploy/serve.py` — entrypoint ASGI : `api.main` + front `dist/` (same-origin) + fallback SPA
- `deploy/systemd/prospection-api.service` — service API+front (`uvicorn deploy.serve:app`, 127.0.0.1:8000)
- `deploy/systemd/ngrok-prospection.service` — tunnel ngrok OAuth-gated (domaine à remplacer)
- `deploy/ngrok/gen_policy.py` — allowlist emails → policy OAuth (match **insensible à la casse**, provider configurable)
- `deploy/ngrok/*.example.*` — templates (les vrais `allow_emails.txt` / `oauth-policy.yml` sont gitignorés)
- `docs/DEPLOY_FRONT_NGROK.md` — runbook complet + ordre de fusion
- `.gitattributes` — LF forcé sur les artefacts deploy (piège CRLF connu)

## Hors PR (volontaire)
- `dist/` (artefact de build, gitignoré) → se rebuild depuis #118
- Emails réels / authtoken / domaine ngrok → hors git (templates + runbook)

## Déjà prouvé en prod
Cette config **tourne et est vérifiée** sur le VPS (2 services systemd `enabled`+`Restart`, gate externe `302 → idp.ngrok.com`). Cette PR ne fait que la tracer proprement.

Ne pas fusionner sans accord (la team merge). Refs #116.
