### PR TITLE
[fusion libre] ci: tests unitaires sur chaque PR (GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Tests unitaires sur chaque PR + push sur main. Les tests @integration
+# (Postgres/Qdrant/Ollama/Claude réels + crédits) sont EXCLUS — ils tournent
+# en local / sur le VPS, jamais en CI. Objectif : rendre le « vert » vérifié,
+# pas mémorisé (cf. échelle Cherny Parallèle -> Autonomie, CLAUDE.md).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: pytest (unitaires)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Installer les dépendances
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Tests unitaires (integration exclus)
+        run: python -m pytest -m "not integration" -q


### PR DESCRIPTION
Ajoute un workflow GitHub Actions qui lance les **tests unitaires** sur chaque PR et push sur `main`. C'est le « prochain garde-fou » de l'échelle Cherny (Parallèle → Autonomie) : rendre le « vert » **vérifié automatiquement**, plus seulement mémorisé/local.

## Ce que ça fait
- `python -m pytest -m "not integration"` sur Python 3.12, `ubuntu-latest`.
- Installe `requirements.txt` (`pytest` + `pytest-asyncio` déjà dedans).
- **Exclut les tests `@integration`** (Postgres/Qdrant/Ollama/Claude réels + crédits) — ils restent en local / sur le VPS.

## Vérifié
- Baseline mesurée sur le VPS (main `907c3ce`) : **304 passed, 12 deselected**.
- `config.settings` a un défaut sur chaque champ (`extra="ignore"`) → la collecte marche sans `.env` en CI.

`[fusion libre]` — indépendant des autres PR. Ne pas fusionner sans accord.
