### PR TITLE
chore(icp): ICP pilote hôtels #35

### DIFF
--- a/config/icp_hotels_pilote.json
+++ b/config/icp_hotels_pilote.json
@@ -1,0 +1,17 @@
+{
+  "nom_entreprise": "Client Pilote — Hôtellerie indépendante",
+  "secteur": "Hôtellerie indépendante",
+  "produit_vendu": "Solution SaaS de gestion hôtelière",
+  "zone_intervention": "Île-de-France (Paris & Hauts-de-Seine)",
+  "nom": "Hôtels indépendants — Paris & Hauts-de-Seine (pilote #35)",
+  "description_icp": "Hôtels indépendants et hébergements touristiques assimilés exploités en entreprise (hôtels de tourisme, hôtels de charme / boutique-hôtels, appart-hôtels, auberges de jeunesse) — structures de 2 à 50 salariés, en activité depuis au moins 2 ans, à Paris (75) et dans les Hauts-de-Seine (92). Cible les exploitants indépendants ayant une réception / des réservations à gérer ; exclut les chaînes, franchises et groupes hôteliers ainsi que les résidences de tourisme et para-hôtelières.",
+  "codes_naf": ["5510Z", "5520Z"],
+  "departements": ["75", "92"],
+  "effectif_min": 2,
+  "effectif_max": 50,
+  "anciennete_min_ans": 2,
+  "exiger_site_web": false,
+  "exiger_email": false,
+  "mots_cles_positifs": ["hotel", "hotellerie", "hebergement", "chambres", "tourisme", "sejour", "reservation", "boutique-hotel", "auberge", "hostel"],
+  "mots_cles_negatifs": ["groupe", "chaine", "franchise", "residence", "residences", "camping"]
+}


### PR DESCRIPTION
## Quoi
Ajoute **`config/icp_hotels_pilote.json`** — l'ICP **pilote hôtels pour #35**, en affinant `config/icp_test.json`. Même schéma/structure que `config/icp_agences_com.json` (PR #112) : un seul fichier de config, aucun code.

## Ancrage (mesuré, pas supposé)
Repris de la comparaison hôtels du 21/08 (VPS, 150 prospects) : **5510Z = 23 qualifiés / 150**, meilleure couverture contact des deux secteurs. Paramètres conservés **tels quels** : dép **75/92**, effectif **2-50**, ancienneté **≥2**, `exiger_*=false`.

## Décisions
- **`codes_naf = ["5510Z", "5520Z"]`.** 5510Z = ancre mesurée. **5520Z (hébergement courte durée) ajouté mais NON mesuré** — vise appart-hôtels / auberges de jeunesse / résidences de tourisme *avec personnel*. **À valider au 1er batch ; sinon revert à `["5510Z"]`** (1 ligne). Exclus 5530Z (camping) et 5590Z (résidences univ./foyers) = hors-ICP. Pas de piège 404 : 5510Z→55.10Z et 5520Z→55.20Z sont de vraies sous-classes (contrairement au 4520Z des garages).
  - ⚠️ **Correction (relecture #39)** : le tail micro (gîtes/meublés/chambres d'hôtes) **ne tombe PAS par `effectif_min`**. `_hors_cible_effectif` renvoie `False` quand l'effectif est inconnu, et l'effectif Sirene est inconnu **~63 %** du temps sur le run 5510Z lui-même (mesuré VPS ; encore plus haut sur 5520Z, non-employeurs). **C'est la couche LLM qui écarte le tail** (les négatifs portent sur le **nom seul** → un gîte « LE CLOS DES VIGNES » n'en matche aucun). Claude le fait démontrablement (SCI/holdings mises à 0 en 5510Z, audit #32) — mais **diluer le lot baisse mécaniquement le % qualifiés**, le KPI même sur lequel #35 est jugé (déjà **15,3 %** vs cible 30 %). D'où : garder 5520Z **et surveiller le 1er batch**, revert prêt.
- **Mots-clés calés sur les vrais matchers** (lus dans le code) : négatifs = mot entier, sans accents, sur le nom (`_matche_exclusion`) → ajout du pluriel **`residences`** que le matcher ne déduit pas de `residence` ; positifs = sous-chaîne `.lower()` accent-sensible (`_score_mots_cles_positifs`) qui sert AUSSI de stoplist name↔domain à l'enrichissement → backbone non-accentué d'`icp_test` conservé + `hotellerie` / `hostel`.
- **`client` / `secteur` / `produit_vendu` / `zone_intervention`** (requis `IcpPayload`, `min_length≥1`) = placeholder pilote. ⚠️ **Avant de semer : remplacer `nom_entreprise` ET ajouter les `contact_*`** — ces derniers sont **absents** du fichier (Optional, omis), donc à ajouter et non à remplacer — pour le vrai client #35 (décision métier).

## Validation (0 crédit)
`scripts/seed_icp.py --from-file config/icp_hotels_pilote.json --dry-run` → **exit 0** (regex NAF/dép, bornes effectif, `min_length`, `extra="forbid"`, règle ≥1 de codes_naf/departements). Même `IcpPayload` → valable pour le seed `--from-file` ET l'API/`CampaignForm`. **Aucun run** (gate crédits + Tavily épuisé jusqu'au 1er sept).

## ⚠️ Lié à #39 (à lire avant d'interpréter les futurs KPI du pilote)
Deux points de #39 touchent directement ce pilote quand il tournera :
- **`osm_tags` absent = cause racine #39.** `IcpPayload` est `extra="forbid"` et `seed_icp` n'écrit pas la colonne → impossible de la porter par ce config. En prod la chaîne A OSM gratuite n'a donc jamais tourné et la couverture mesurée vient du cascade dégradé (Tavily→DDG). Pour l'activer sur hôtels : poser `criteres_ciblage.osm_tags = ["tourism=hotel"]` en base après le seed.
- **Dérive du KPI « qualifiés » (#39).** `POST /outcome` écrit `statut`, alors que `/api/kpis` et le rapport hebdo comptent `statut='qualifie'` → **chaque RDV saisi décrémente le compteur de qualifiés** (mesuré : 43 à score≥60 = 37 restants + 6 passés en RDV ; `appels` = 0 ligne). Tant que ce n'est pas corrigé, le nombre de qualifiés de ce pilote **s'érodera au fil de la prise de contact** — à garder en tête (ou corriger #39) avant de piloter #35 sur ce chiffre.

## Fusion
Base `main`, autonome, **aucune dépendance** de merge. `Refs #35` (ne clôt pas : le pilote réel exige le vrai client + un run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
